### PR TITLE
docs: add three-step quickstart for adopting Juror

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,69 @@ receipt.**
 
 ---
 
+## Add it to your repo
+
+Three steps, about two minutes. No app to install, no account to create, no repository index
+to build — it runs on your own GitHub Actions runner, and your code never leaves it beyond
+the model API call itself.
+
+**1 — Drop in the workflow.** Save this as `.github/workflows/juror.yml`:
+
+```yaml
+name: Juror
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }   # full history: review policy is read from the base revision
+      - uses: juror-dev/juror@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          OPENAI_API_KEY:    ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          XAI_API_KEY:       ${{ secrets.XAI_API_KEY }}
+          FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+```
+
+**2 — Add at least one provider key.** *Settings → Secrets and variables → Actions*, or from
+your terminal:
+
+```bash
+gh secret set OPENAI_API_KEY      # one key is enough to start
+gh secret set ANTHROPIC_API_KEY   # every extra key adds another juror
+```
+
+Any key you leave out is skipped with a note in the receipt. One key gets you a working
+single-model review; four gets you the full jury. Degrade, never fail.
+
+**3 — Open a pull request.** Juror posts a sticky *Juror is reviewing…* comment right away,
+then replaces it in place with the findings, the merge score, and the bill.
+
+That's the whole setup — `.juror.yml` is optional, and every default is listed under
+[Configuration](#configuration).
+
+<details><summary><b>Want to try it on a real PR before committing a workflow file?</b></summary><br>
+
+Same binary, same code path, nothing posted unless you ask:
+
+```bash
+export OPENAI_API_KEY=…
+npx juror review --pr 1234 --repo owner/name          # prints to your terminal
+npx juror review --pr 1234 --repo owner/name --post   # ...and posts it
+```
+
+</details>
+
+---
+
 ## Why
 
 Single-model PR bots have three problems, in order of how much they cost you:
@@ -133,32 +196,10 @@ leaving a spinner behind forever.
 
 ### GitHub Action
 
-```yaml
-name: Juror
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-permissions:
-  contents: read
-  pull-requests: write
-jobs:
-  review:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
-      - uses: juror-dev/juror@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY:    ${{ secrets.OPENAI_API_KEY }}
-          FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
-          XAI_API_KEY:       ${{ secrets.XAI_API_KEY }}
-```
-
-**Any model whose key is absent is skipped with a note in the receipt.** A repo with one key
-still gets a working single-model review. Degrade, never fail.
+The workflow file is in [Add it to your repo](#add-it-to-your-repo) above. Beyond
+`github-token`, every Action input is optional: `preset`, `models`, `config`,
+`cost-target-usd`, `post` (set `false` for a dry run), and `pr-number`. They are documented
+with their defaults in [`action.yml`](action.yml).
 
 ### Locally
 


### PR DESCRIPTION
## TL;DR

The README led with rationale and buried the workflow file halfway down under Install. This puts a copy-pasteable three-step setup (workflow file → one provider key → open a PR) directly under the hero, so a first-time reader can adopt Juror without scrolling past the "Why" section.

## Summary

- New **Add it to your repo** section as the first content after the tagline: the workflow YAML, `gh secret set` one-liners, and what to expect on the first PR.
- Moved the "any absent key is skipped / degrade, never fail" note up into step 2, where a new user actually needs it.
- Added an inline comment explaining why `fetch-depth: 0` is required (base-revision `AGENTS.md` policy loading).
- Reordered the env keys so `OPENAI_API_KEY` is first, matching the "one key is enough to start" advice.
- Collapsed a try-before-you-commit `npx` path into a `<details>` block.
- **Install → GitHub Action** no longer repeats the YAML; it links to the quickstart and lists the optional Action inputs, pointing at `action.yml` for defaults.

Docs only — no source, config, or test changes.

## Review focus

Two pre-existing issues are now more visible because they sit in the first screenful, and are **not** fixed here (they need a decision first):

- The quickstart tells adopters `uses: juror-dev/juror@v1`, but neither the `juror-dev` org nor that repo exists — the real repo is `cderinbogaz/juror`. Same slug is in `package.json`, `action.yml`, and `src/render/receipt.ts:170` (where it builds badge/pricing links into every posted review).
- `npx juror` resolves to an unrelated package that already owns that name on npm; `@juror/cli` is unpublished.

Worth deciding whether `juror-dev` is a planned org before this is the front door.

## Test plan

- [ ] Rendered preview: quickstart appears directly under the hero, headings and the `<details>` block render correctly
- [ ] Anchor links `#add-it-to-your-repo` and `#configuration` resolve
- [ ] Quickstart YAML matches the inputs declared in `action.yml`