### PR TITLE
chore: rename to Juror AI and repoint slug at juror-ai/juror

### DIFF
--- a/.github/workflows/juror.yml
+++ b/.github/workflows/juror.yml
@@ -24,7 +24,7 @@ jobs:
 
       # Never execute action code from the pull request while provider secrets are present.
       # Dependabot can deliberately update this immutable revision after the reviewed code lands.
-      - uses: cderinbogaz/juror@24721b8b02ba3cdffbef1ecbcf148a69b029c2ea
+      - uses: juror-ai/juror@24721b8b02ba3cdffbef1ecbcf148a69b029c2ea
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         env:

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 <br>
 
-[![CI](https://img.shields.io/github/actions/workflow/status/cderinbogaz/juror/ci.yml?branch=main&style=flat-square&label=ci&labelColor=1b1f24&color=3fb950)](https://github.com/cderinbogaz/juror/actions/workflows/ci.yml) [![Juror reviews Juror](https://img.shields.io/badge/dogfooded-juror%20reviews%20juror-F2B33D?style=flat-square&labelColor=1b1f24)](.github/workflows/juror.yml) [![Node](https://img.shields.io/badge/node-%E2%89%A520-8593a8?style=flat-square&labelColor=1b1f24)](package.json) [![License](https://img.shields.io/badge/license-MIT-8593a8?style=flat-square&labelColor=1b1f24)](LICENSE)
+[![CI](https://img.shields.io/github/actions/workflow/status/juror-ai/juror/ci.yml?branch=main&style=flat-square&label=ci&labelColor=1b1f24&color=3fb950)](https://github.com/juror-ai/juror/actions/workflows/ci.yml) [![Juror reviews Juror](https://img.shields.io/badge/dogfooded-juror%20reviews%20juror-F2B33D?style=flat-square&labelColor=1b1f24)](.github/workflows/juror.yml) [![Node](https://img.shields.io/badge/node-%E2%89%A520-8593a8?style=flat-square&labelColor=1b1f24)](package.json) [![License](https://img.shields.io/badge/license-MIT-8593a8?style=flat-square&labelColor=1b1f24)](LICENSE)
 
 </div>
 
 ```
-npx juror review --pr 1234
+npx juror-ai review --pr 1234
 ```
 
 **N frontier models review your PR in parallel, each through its own native agent
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }   # full history: review policy is read from the base revision
-      - uses: juror-dev/juror@v1
+      - uses: juror-ai/juror@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         env:
@@ -77,8 +77,8 @@ Same binary, same code path, nothing posted unless you ask:
 
 ```bash
 export OPENAI_API_KEY=…
-npx juror review --pr 1234 --repo owner/name          # prints to your terminal
-npx juror review --pr 1234 --repo owner/name --post   # ...and posts it
+npx juror-ai review --pr 1234 --repo owner/name          # prints to your terminal
+npx juror-ai review --pr 1234 --repo owner/name --post   # ...and posts it
 ```
 
 </details>
@@ -206,7 +206,7 @@ with their defaults in [`action.yml`](action.yml).
 The same binary, the same code path, no CI-only surprises:
 
 ```bash
-npm i -g @juror/cli
+npm i -g juror-ai
 
 juror review --base main                         # review your working branch
 juror review --pr 1234 --repo owner/name         # review a PR, print to the terminal
@@ -275,7 +275,7 @@ juror review --mode ultra --pr 1234 --repo owner/name
 ```
 
 ```yaml
-- uses: juror-dev/juror@v1
+- uses: juror-ai/juror@v1
   with:
     preset: high
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: Juror
+name: Juror AI
 description: Multi-model PR review that shows you the bill — duplicate findings collapse into one, with optional agreement filtering.
-author: juror-dev
+author: juror-ai
 branding:
   icon: check-circle
   color: purple

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@juror/cli",
+  "name": "juror-ai",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@juror/cli",
+      "name": "juror-ai",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "@juror/cli",
+  "name": "juror-ai",
   "version": "0.1.0",
   "description": "Multi-model PR review that shows you the bill. Duplicate findings collapse into one, with optional agreement filtering.",
   "license": "MIT",
   "type": "module",
   "bin": {
-    "juror": "./dist/cli.js"
+    "juror": "./dist/cli.js",
+    "juror-ai": "./dist/cli.js"
   },
   "engines": {
     "node": ">=20"
@@ -43,6 +44,6 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/juror-dev/juror.git"
+    "url": "git+https://github.com/juror-ai/juror.git"
   }
 }

--- a/src/render/receipt.ts
+++ b/src/render/receipt.ts
@@ -167,7 +167,7 @@ function noteText(n: ReceiptNote): string {
 }
 
 /** Our own repo, pinned: the receipt links must not drift with `main`. */
-export const REPO_SLUG = 'juror-dev/juror';
+export const REPO_SLUG = 'juror-ai/juror';
 
 /**
  * `v1` is the action's floating major tag — the only ref we can name when the caller

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -136,7 +136,7 @@ function makeFake(createReviewImpl?: () => Promise<void>): Fake {
   const createReview = vi.fn(createReviewImpl ?? (async () => {}));
 
   const client = {
-    repo: 'juror-dev/juror',
+    repo: 'juror-ai/juror',
     request: vi.fn(async () => {
       throw new Error('publish must not reach for a raw request');
     }),
@@ -172,8 +172,8 @@ function unprocessable(body: unknown): GitHubApiError {
   const raw = JSON.stringify(body);
   return new GitHubApiError(
     422,
-    '/repos/juror-dev/juror/pulls/7/reviews',
-    'GitHub API 422 on POST /repos/juror-dev/juror/pulls/7/reviews: Validation Failed',
+    '/repos/juror-ai/juror/pulls/7/reviews',
+    'GitHub API 422 on POST /repos/juror-ai/juror/pulls/7/reviews: Validation Failed',
     body,
     raw,
   );
@@ -194,7 +194,7 @@ describe('live sticky status', () => {
     headSha: 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678',
     version: '0.1.0',
     modelLabels: ['DeepSeek V4 Flash', 'Sonnet 5'],
-    jobUrl: 'https://github.com/juror-dev/juror/actions/runs/123',
+    jobUrl: 'https://github.com/juror-ai/juror/actions/runs/123',
     dryRun,
   });
 

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -551,7 +551,7 @@ describe('renderInlineComment', () => {
     );
 
     expect(body).toContain(
-      '<img alt="P1" src="https://raw.githubusercontent.com/juror-dev/juror/v0.4.1/assets/badges/p1.svg" align="top">',
+      '<img alt="P1" src="https://raw.githubusercontent.com/juror-ai/juror/v0.4.1/assets/badges/p1.svg" align="top">',
     );
     expect(body).toContain('**Clipboard write loses transient activation**');
     expect(body).toContain('`●●●○` **3/4 models** — Opus 5, GPT-5.6 Sol, Kimi K3 · verified · convention: `apps/AGENTS.md`');


### PR DESCRIPTION
## TL;DR

Unblocks Marketplace publishing. The action name `Juror` is rejected by GitHub because a Marketplace name cannot match an existing user and `github.com/juror` is taken, so the listing becomes `Juror AI`. At the same time this repoints every `juror-dev/juror` reference — an org that never existed — at `juror-ai/juror`.

Stacked on #2; merge that first.

## Summary

- `action.yml` — `name: Juror AI`, author `juror-ai`
- `src/render/receipt.ts` — `REPO_SLUG` → `juror-ai/juror`. This was the only *functional* bug in the set: it builds the severity-badge and `pricing.json` links embedded in every posted review, so those were 404ing against a nonexistent org.
- `README.md` — both `uses:` lines, the CI badge, and the npm commands
- `package.json` / lockfile — package renamed `@juror/cli` → `juror-ai`
- `.github/workflows/juror.yml` — dogfood `uses:` repointed (SHA pin unchanged)
- `test/render.test.ts`, `test/publish.test.ts` — fixtures follow the slug

## Review focus

- **`bin` now has two entries.** `juror-ai` was added alongside `juror` so `npx juror-ai review` resolves deterministically rather than relying on npx's single-bin fallback. `juror` remains the primary command after a global install.
- **This lands before the org exists.** `juror-ai` was verified available on GitHub and npm, but the slug is only correct once the org is created and the repo transferred. Links stay broken in the interim — no regression, since `juror-dev` was already dead.
- **npm `juror` is a squatted stub** (v0.0.0, no repo, single version) — reclaiming it isn't practical, hence `juror-ai`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 328 passed, 27 files
- [ ] After transfer: badge URLs in a posted review resolve against `juror-ai/juror`
- [ ] `npx juror-ai review --help` works once published to npm