### PR TITLE
chore: release v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juror-ai",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juror-ai",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juror-ai",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Multi-model PR review that shows you the bill. Duplicate findings collapse into one, with optional agreement filtering.",
   "license": "MIT",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ import { checkoutAt, type EphemeralCheckout } from './util/worktree.js';
 import { evaluateBenchmark, parseBenchmarkCorpus, renderBenchmark } from './benchmark.js';
 import { loadAgentInstructions } from './instructions.js';
 
-export const VERSION = '0.1.0';
+export const VERSION = '1.0.0';
 
 const USAGE = `
 juror ${VERSION} — multi-model PR review that shows you the bill


### PR DESCRIPTION
## TL;DR

Cuts the version for the first Marketplace release. `v1.0.0` is required because the README and `action.yml` document consumption as `juror-ai/juror@v1`, and a floating `v1` tag off a `0.x` version would be incoherent.

## Summary

- `src/cli.ts:41` `VERSION` and `package.json`/lockfile → `1.0.0`

## Review focus

`VERSION` in `src/cli.ts` is a **second source of truth** independent of `package.json`. It feeds `pinnedTag()` in `src/render/receipt.ts`, which builds the `pricing.json` permalink embedded in every posted receipt. Bumping one without the other ships receipts pointing at a tag that was never cut — the same failure mode as the `juror-dev` slug just fixed. Worth collapsing these into one source later.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 328 passed
- [x] `npm ci` succeeds (lockfile consistent)