### PR TITLE
feat: make fast the default jury preset

### DIFF
--- a/.juror.yml
+++ b/.juror.yml
@@ -10,11 +10,11 @@ version: 1
 # Built-in jury selection: fast | balanced | high | ultra. Missing provider keys simply
 # skip their models. `models:` can replace the selected preset with a fully custom jury.
 #
-# balanced (default): GPT-5.6 Terra max + Grok 4.5 high + Kimi K3
+# fast (default):     GPT-5.6 Luna + DeepSeek V4 Flash, both at low reasoning effort
+# balanced:           GPT-5.6 Terra max + Grok 4.5 high + Kimi K3
 # high:               GPT-5.6 Sol + Opus 5 + Grok 4.5
-# fast:               GPT-5.6 Luna + DeepSeek V4 Flash, both at low reasoning effort
 # ultra:              every model above, using the higher reasoning settings
-preset: balanced
+preset: fast
 
 # How independent findings are deduplicated and, optionally, agreement-filtered.
 consensus:
@@ -29,8 +29,8 @@ consensus:
 
   # The preset selects an included verifier/referee automatically. Override either with a
   # configured model id, or set it to null to disable that pass entirely.
-  # verify_model: kimi-k3
-  # referee_model: kimi-k3
+  # verify_model: deepseek-v4-flash-0731
+  # referee_model: deepseek-v4-flash-0731
 
   # Code-aware similarity nominates possible duplicates for the referee; it never merges
   # semantic reports by itself. Exact structured claims collapse locally. `distinct` is

--- a/README.md
+++ b/README.md
@@ -262,8 +262,8 @@ Juror ships four jury presets. Models whose provider key is unavailable are skip
 
 | Preset | Jury | Intended use |
 |---|---|---|
-| `fast` | GPT-5.6 Luna via Codex/OpenAI (`low`) · DeepSeek V4 Flash via opencode/Fireworks (`low`) | Lowest latency and cost |
-| `balanced` **(default)** | GPT-5.6 Terra via Codex/OpenAI (`max`) · Grok 4.5 via Grok Build/xAI (`high`) · Kimi K3 via Kimi Code/Fireworks (`max`) | Strong provider diversity without the full burn |
+| `fast` **(default)** | GPT-5.6 Luna via Codex/OpenAI (`low`) · DeepSeek V4 Flash via opencode/Fireworks (`low`) | Lowest latency and cost |
+| `balanced` | GPT-5.6 Terra via Codex/OpenAI (`max`) · Grok 4.5 via Grok Build/xAI (`high`) · Kimi K3 via Kimi Code/Fireworks (`max`) | Strong provider diversity without the full burn |
 | `high` | GPT-5.6 Sol via Codex/OpenAI (`high`) · Opus 5 via Claude Code/Anthropic · Grok 4.5 via Grok Build/xAI (`high`) | Higher-confidence frontier jury |
 | `ultra` | Every model from the other presets (seven total), using their higher reasoning settings | Maximum coverage; highest token and cost use |
 
@@ -284,7 +284,7 @@ juror review --mode ultra --pr 1234 --repo owner/name
 
 ```yaml
 version: 1
-preset: balanced
+preset: fast
 
 consensus:
   min_agreement: all             # all (literal unanimity) | majority | <number>

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: Path to the Juror config file. Defaults to .juror.yml at the repo root.
     required: false
   preset:
-    description: Jury preset (fast, balanced, high, or ultra). Defaults to balanced unless config overrides it.
+    description: Jury preset (fast, balanced, high, or ultra). Defaults to fast unless config overrides it.
     required: false
   models:
     description: Comma-separated model ids to run, overriding the config's enabled set.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juror-ai",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juror-ai",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juror-ai",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Multi-model PR review that shows you the bill. Duplicate findings collapse into one, with optional agreement filtering.",
   "license": "MIT",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ import { checkoutAt, type EphemeralCheckout } from './util/worktree.js';
 import { evaluateBenchmark, parseBenchmarkCorpus, renderBenchmark } from './benchmark.js';
 import { loadAgentInstructions } from './instructions.js';
 
-export const VERSION = '1.0.0';
+export const VERSION = '1.1.0';
 
 const USAGE = `
 juror ${VERSION} — multi-model PR review that shows you the bill
@@ -56,7 +56,7 @@ Options
   --repo-dir <path>      Repository checkout to read (default: cwd)
   --head <ref>           Head ref for local mode (default: HEAD)
   --config <path>        Config file (default: .juror.yml in the repo)
-  --preset <name>        Jury preset: fast, balanced (default), high, or ultra
+  --preset <name>        Jury preset: fast (default), balanced, high, or ultra
   --mode <name>          Alias for --preset
   --models <a,b,c>       Only run these model ids
   --post                 Post the review to the pull request (requires --pr and GITHUB_TOKEN)

--- a/src/config.ts
+++ b/src/config.ts
@@ -199,7 +199,7 @@ export function applyReviewPreset(config: JurorConfig, preset: ReviewPreset): Ju
 }
 
 export function defaultConfig(): JurorConfig {
-  const preset: ReviewPreset = 'balanced';
+  const preset: ReviewPreset = 'fast';
   const consensusModel = PRESET_DEFINITIONS[preset].consensusModel;
   return {
     version: 1,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -34,43 +34,55 @@ afterEach(() => {
 });
 
 describe('defaultConfig', () => {
-  it('defaults to the balanced three-model jury', () => {
+  it('defaults to the fast two-model jury', () => {
     const c = defaultConfig();
-    expect(c.preset).toBe('balanced');
+    expect(c.preset).toBe('fast');
     expect(c.review.publish_mode).toBe('all');
     expect(c.review.max_turns).toBe(0);
     expect(c.consensus.min_agreement).toBe('all');
-    expect(c.models.map((m) => m.id)).toEqual(['gpt-5.6-terra', 'grok-4.5', 'kimi-k3']);
-    expect(c.models[0]?.args?.['reasoning_effort']).toBe('max');
-    expect(c.models[1]?.args?.['reasoning_effort']).toBe('high');
-    expect(c.models[2]?.harness).toBe('kimi-code');
-    expect(c.models[2]?.secret).toBe('FIREWORKS_API_KEY');
-    expect(c.models[2]?.harness_model).toBe('accounts/fireworks/models/kimi-k3');
-    expect(c.models[2]?.pricing_key).toBe('accounts/fireworks/models/kimi-k3');
-    expect(c.consensus.verify_model).toBe('kimi-k3');
-    expect(c.consensus.referee_model).toBe('kimi-k3');
+    expect(c.models.map((m) => m.id)).toEqual(['gpt-5.6-luna', 'deepseek-v4-flash-0731']);
+    expect(c.models[0]?.harness).toBe('codex');
+    expect(c.models[0]?.secret).toBe('OPENAI_API_KEY');
+    expect(c.models[0]?.args?.['reasoning_effort']).toBe('low');
+    expect(c.models[1]?.harness).toBe('opencode');
+    expect(c.models[1]?.secret).toBe('FIREWORKS_API_KEY');
+    expect(c.models[1]?.harness_model).toBe(
+      'fireworks-ai/accounts/fireworks/models/deepseek-v4-flash-0731',
+    );
+    expect(c.models[1]?.pricing_key).toBe('accounts/fireworks/models/deepseek-v4-flash-0731');
+    // The preset's `low` overrides this model's built-in `variant: high`.
+    expect(c.models[1]?.args?.['variant']).toBe('low');
+    expect(c.consensus.verify_model).toBe('deepseek-v4-flash-0731');
+    expect(c.consensus.referee_model).toBe('deepseek-v4-flash-0731');
   });
 
   it('hands out an independent copy each call', () => {
     const a = defaultConfig();
     a.review.severity_floor = 'P0';
     a.review.paths_ignore.push('mutated/**');
-    if (a.models[0]?.args) a.models[0].args['reasoning_effort'] = 'low';
+    // Must differ from the default, or a shared reference would still read back as default.
+    if (a.models[0]?.args) a.models[0].args['reasoning_effort'] = 'max';
     const b = defaultConfig();
     expect(b.review.severity_floor).toBe('P3');
     expect(b.review.paths_ignore).not.toContain('mutated/**');
-    expect(b.models[0]?.args?.['reasoning_effort']).toBe('max');
+    expect(b.models[0]?.args?.['reasoning_effort']).toBe('low');
   });
 
-  it('ships the requested fast, high, and ultra preset memberships', () => {
+  it('ships the requested fast, balanced, high, and ultra preset memberships', () => {
     const base = defaultConfig();
     const fast = applyReviewPreset(base, 'fast');
+    const balanced = applyReviewPreset(base, 'balanced');
     const high = applyReviewPreset(base, 'high');
     const ultra = applyReviewPreset(base, 'ultra');
 
     expect(fast.models.map((m) => m.id)).toEqual(['gpt-5.6-luna', 'deepseek-v4-flash-0731']);
     expect(fast.models.map((m) => m.args?.['reasoning_effort'] ?? m.args?.['variant'])).toEqual(['low', 'low']);
     expect(fast.consensus.referee_model).toBe('deepseek-v4-flash-0731');
+    // No longer the default, so this is the only place its membership is pinned.
+    expect(balanced.models.map((m) => m.id)).toEqual(['gpt-5.6-terra', 'grok-4.5', 'kimi-k3']);
+    expect(balanced.models[0]?.args?.['reasoning_effort']).toBe('max');
+    expect(balanced.models[1]?.args?.['reasoning_effort']).toBe('high');
+    expect(balanced.consensus.referee_model).toBe('kimi-k3');
     expect(high.models.map((m) => m.id)).toEqual(['gpt-5.6-sol', 'claude-opus-5', 'grok-4.5']);
     expect(high.consensus.referee_model).toBe('grok-4.5');
     expect(ultra.models.map((m) => m.id)).toEqual([
@@ -196,7 +208,7 @@ describe('loadConfig', () => {
     expect(config.consensus.referee_model).toBe('claude-opus-5');
   });
 
-  it('keeps balanced and reports an unknown preset', () => {
+  it('keeps the default preset and reports an unknown one', () => {
     const dir = repoWith({ '.juror.yml': 'preset: enormous\n' });
     const { config, problems } = loadConfig(dir);
     expect(config).toEqual(defaultConfig());


### PR DESCRIPTION
## TL;DR

Switches the default preset from `balanced` to `fast`. The default jury goes from three models (GPT-5.6 Terra + Grok 4.5 + Kimi K3) to two (GPT-5.6 Luna + DeepSeek V4 Flash, both at low reasoning effort), and the default referee/verifier moves from `kimi-k3` to `deepseek-v4-flash-0731`. Released as **1.1.0**.

## Summary

- `src/config.ts` — `defaultConfig()` preset → `fast`
- `src/cli.ts` — help text, and `VERSION` → `1.1.0`
- `action.yml` — `preset` input description
- `.juror.yml` — the repo's own config, which states it shows every knob at its default; preset list reordered and the `verify_model`/`referee_model` example comments updated to the fast preset's referee
- `README.md` — `**(default)**` moved to `fast` in the preset table, config example updated
- `test/config.test.ts` — default-config assertions rewritten for the fast jury

## Review focus

Three things worth a look beyond the mechanical swap:

1. **A test would have gone vacuous.** `hands out an independent copy each call` mutated `reasoning_effort` to `'low'` and asserted the next call read back `'max'`. With `fast` as default, `'low'` *is* the default, so a shared reference would still have read `'low'` and the test would pass while detecting nothing. Mutation value flipped to `'max'`, assertion to `'low'`.
2. **Coverage gap closed.** `balanced` membership was only pinned by the default-config test. Moving the default off it would have left that preset entirely unasserted, so it's now covered explicitly in the preset-membership test.
3. **This repo now dogfoods `fast`.** `.juror.yml` declares itself to show defaults, so it follows the new default — meaning Juror's own PRs get reviewed by a 2-model jury instead of 3. Deliberate, but revert that one line if you'd rather keep reviewing this repo with `balanced`.

Not changed: the sample receipt under "What it posts" still shows a 3-model, $0.91 review. It's illustrative, and I'd rather not invent numbers for a 2-model run in a project whose whole pitch is never fabricating cost figures.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 328 passed
- [x] Runtime check: fresh repo with no `.juror.yml` resolves to `preset: fast`, jury `gpt-5.6-luna (low), deepseek-v4-flash-0731 (low)`, referee `deepseek-v4-flash-0731`
- [x] `juror --help` shows `fast (default)`