### PR TITLE
fix(codex): authenticate Codex runs; raise fast jury to Luna max + DeepSeek high

### DIFF
--- a/.juror.yml
+++ b/.juror.yml
@@ -10,7 +10,7 @@ version: 1
 # Built-in jury selection: fast | balanced | high | ultra. Missing provider keys simply
 # skip their models. `models:` can replace the selected preset with a fully custom jury.
 #
-# fast (default):     GPT-5.6 Luna + DeepSeek V4 Flash, both at low reasoning effort
+# fast (default):     GPT-5.6 Luna max + DeepSeek V4 Flash high
 # balanced:           GPT-5.6 Terra max + Grok 4.5 high + Kimi K3
 # high:               GPT-5.6 Sol + Opus 5 + Grok 4.5
 # ultra:              every model above, using the higher reasoning settings

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Juror ships four jury presets. Models whose provider key is unavailable are skip
 
 | Preset | Jury | Intended use |
 |---|---|---|
-| `fast` **(default)** | GPT-5.6 Luna via Codex/OpenAI (`low`) · DeepSeek V4 Flash via opencode/Fireworks (`low`) | Lowest latency and cost |
+| `fast` **(default)** | GPT-5.6 Luna via Codex/OpenAI (`max`) · DeepSeek V4 Flash via opencode/Fireworks (`high`) | Smallest, cheapest jury |
 | `balanced` | GPT-5.6 Terra via Codex/OpenAI (`max`) · Grok 4.5 via Grok Build/xAI (`high`) · Kimi K3 via Kimi Code/Fireworks (`max`) | Strong provider diversity without the full burn |
 | `high` | GPT-5.6 Sol via Codex/OpenAI (`high`) · Opus 5 via Claude Code/Anthropic · Grok 4.5 via Grok Build/xAI (`high`) | Higher-confidence frontier jury |
 | `ultra` | Every model from the other presets (seven total), using their higher reasoning settings | Maximum coverage; highest token and cost use |

--- a/src/config.ts
+++ b/src/config.ts
@@ -132,8 +132,8 @@ const PRESET_DEFINITIONS: Record<ReviewPreset, PresetDefinition> = {
     modelIds: ['gpt-5.6-luna', 'deepseek-v4-flash-0731'],
     consensusModel: 'deepseek-v4-flash-0731',
     args: {
-      'gpt-5.6-luna': { reasoning_effort: 'low' },
-      'deepseek-v4-flash-0731': { variant: 'low' },
+      'gpt-5.6-luna': { reasoning_effort: 'max' },
+      'deepseek-v4-flash-0731': { variant: 'high' },
     },
   },
   balanced: {

--- a/src/harness/codex.ts
+++ b/src/harness/codex.ts
@@ -173,6 +173,19 @@ export const codexHarness: Harness = {
     ].join('\n');
     writeFileSync(join(codexHome, 'config.toml'), config, { encoding: 'utf8', mode: 0o600 });
 
+    // Codex reads credentials from `$CODEX_HOME/auth.json`, never from `OPENAI_API_KEY` in
+    // the environment. The private home above starts empty, so without this the CLI sends
+    // no Authorization header at all and every turn dies on a 401 before it bills anything.
+    // This is the same file `codex login --with-api-key` writes, minus the subprocess.
+    writeFileSync(
+      join(codexHome, 'auth.json'),
+      JSON.stringify({
+        auth_mode: 'apikey',
+        OPENAI_API_KEY: ctx.providerKey ?? ctx.env['OPENAI_API_KEY'],
+      }),
+      { encoding: 'utf8', mode: 0o600 },
+    );
+
     const argv = [
       'codex',
       'exec',

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -80,6 +80,17 @@ describe('codex parse() — canonical usage', () => {
     rmSync(context.scratchDir, { recursive: true, force: true });
   });
 
+  // Codex only authenticates from `$CODEX_HOME/auth.json`; it ignores OPENAI_API_KEY in the
+  // environment. The private home starts empty, so without this every turn 401s.
+  it('provisions api-key auth inside the private CODEX_HOME', () => {
+    const context = { ...ctx(), providerKey: 'sk-test-key' };
+    const command = codexHarness.command(context);
+    const home = command.env['CODEX_HOME'] as string;
+    const auth = JSON.parse(readFileSync(join(home, 'auth.json'), 'utf8'));
+    expect(auth).toEqual({ auth_mode: 'apikey', OPENAI_API_KEY: 'sk-test-key' });
+    rmSync(context.scratchDir, { recursive: true, force: true });
+  });
+
   it('subtracts cached tokens from the reported input total', () => {
     const r = codexHarness.parse(io(jsonl([TURN_COMPLETED])), ctx());
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -43,15 +43,15 @@ describe('defaultConfig', () => {
     expect(c.models.map((m) => m.id)).toEqual(['gpt-5.6-luna', 'deepseek-v4-flash-0731']);
     expect(c.models[0]?.harness).toBe('codex');
     expect(c.models[0]?.secret).toBe('OPENAI_API_KEY');
-    expect(c.models[0]?.args?.['reasoning_effort']).toBe('low');
+    expect(c.models[0]?.args?.['reasoning_effort']).toBe('max');
     expect(c.models[1]?.harness).toBe('opencode');
     expect(c.models[1]?.secret).toBe('FIREWORKS_API_KEY');
     expect(c.models[1]?.harness_model).toBe(
       'fireworks-ai/accounts/fireworks/models/deepseek-v4-flash-0731',
     );
     expect(c.models[1]?.pricing_key).toBe('accounts/fireworks/models/deepseek-v4-flash-0731');
-    // The preset's `low` overrides this model's built-in `variant: high`.
-    expect(c.models[1]?.args?.['variant']).toBe('low');
+    // The preset pins `high` explicitly rather than inheriting the model's built-in default.
+    expect(c.models[1]?.args?.['variant']).toBe('high');
     expect(c.consensus.verify_model).toBe('deepseek-v4-flash-0731');
     expect(c.consensus.referee_model).toBe('deepseek-v4-flash-0731');
   });
@@ -65,7 +65,7 @@ describe('defaultConfig', () => {
     const b = defaultConfig();
     expect(b.review.severity_floor).toBe('P3');
     expect(b.review.paths_ignore).not.toContain('mutated/**');
-    expect(b.models[0]?.args?.['reasoning_effort']).toBe('low');
+    expect(b.models[0]?.args?.['reasoning_effort']).toBe('max');
   });
 
   it('ships the requested fast, balanced, high, and ultra preset memberships', () => {
@@ -76,7 +76,7 @@ describe('defaultConfig', () => {
     const ultra = applyReviewPreset(base, 'ultra');
 
     expect(fast.models.map((m) => m.id)).toEqual(['gpt-5.6-luna', 'deepseek-v4-flash-0731']);
-    expect(fast.models.map((m) => m.args?.['reasoning_effort'] ?? m.args?.['variant'])).toEqual(['low', 'low']);
+    expect(fast.models.map((m) => m.args?.['reasoning_effort'] ?? m.args?.['variant'])).toEqual(['max', 'high']);
     expect(fast.consensus.referee_model).toBe('deepseek-v4-flash-0731');
     // No longer the default, so this is the only place its membership is pinned.
     expect(balanced.models.map((m) => m.id)).toEqual(['gpt-5.6-terra', 'grok-4.5', 'kimi-k3']);


### PR DESCRIPTION
Two changes, split into one commit each.

## 1. `fix(codex)` — every OpenAI model was failing to authenticate

The Codex harness builds a private `CODEX_HOME` so user OAuth state, MCP servers, and global config cannot enter a review. That home starts empty, and **Codex reads credentials only from `$CODEX_HOME/auth.json` — it ignores `OPENAI_API_KEY` in the environment.** So Codex sent no `Authorization` header and every turn died on `401 Unauthorized` before billing anything.

It surfaced as `no usable report`, not as an auth error, which is why it went unnoticed. This disabled **every `harness: codex` model — Luna, Sol, and Terra — across all four presets, including the default.**

Measured on `textcortex/platform#10333`: Luna failed both attempts in 38s before this change, and returns 7 findings after. Verified the key itself was fine (`/v1/models` → 200) and that the failure was independent of reasoning effort (`low` 401s identically).

The fix writes the same file `codex login --with-api-key` produces, mode `0600`, inside the home the permission profile already denies to model-run shell commands.

## 2. `feat(config)` — fast jury reasoning settings

`fast` is now the default preset, so these settings decide out-of-the-box quality. Luna `low → max`, DeepSeek `low → high`.

DeepSeek stays at `high` rather than `max`. `max` is a valid variant (confirmed in opencode's model metadata), but on #10333 it returned findings with no `path` field and all were dropped.

## Benchmark

10 merged `textcortex/platform` PRs not previously benchmarked, spanning backend concurrency, a DB migration, CI, and web; 2–33 files each.

| | Juror (fast) | Incumbent |
|---|---|---|
| Published findings | 43 | 13 |
| Cost | $4.25 | — |

Overlap by file and line proximity: 4 of the incumbent's 13 have a Juror finding within 40 lines, 3 more share a file, 6 have no Juror finding in that file.

**These counts are unadjudicated.** Per `docs/benchmarking.md`, mapping a report to a real defect is human work, and none has happened — 43 vs 13 is volume, not recall. Two biases: only PRs where the incumbent found something were selected, and `publish_mode: all` is a high-recall mode.

## Known issue this does not fix

**Luna at `max` collides with the 900s `per_model_timeout_seconds`.** Across the 10 PRs:

- #10335 — 900s, killed, zero findings published for that PR
- #10301 — 813s (90% of the wall)
- #10300 — 751s (83%)

One hard failure in ten, two near-misses. `low` had headroom that `max` spends. Raising `per_model_timeout_seconds` to ~1800 would fix it, but that is a global affecting all four presets, so it is deliberately not in this PR.

## Verification

`npm run typecheck`, `npm run build`, `npm test` — 329 tests across 27 files, all passing. Includes a regression test pinning the `auth.json` contents.