### PR TITLE
chore: release v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juror-ai",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juror-ai",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juror-ai",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Multi-model PR review that shows you the bill. Duplicate findings collapse into one, with optional agreement filtering.",
   "license": "MIT",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ import { checkoutAt, type EphemeralCheckout } from './util/worktree.js';
 import { evaluateBenchmark, parseBenchmarkCorpus, renderBenchmark } from './benchmark.js';
 import { loadAgentInstructions } from './instructions.js';
 
-export const VERSION = '1.1.0';
+export const VERSION = '1.2.0';
 
 const USAGE = `
 juror ${VERSION} — multi-model PR review that shows you the bill


### PR DESCRIPTION
Version bump for v1.2.0. Contents shipped by #6:

- `fix(codex)` — Codex never authenticated. The harness builds a private empty `CODEX_HOME`, but Codex reads credentials only from `$CODEX_HOME/auth.json` and ignores `OPENAI_API_KEY` in the environment, so every turn 401'd before billing. This disabled **Luna, Sol, and Terra across all four presets**, including the default, and surfaced as `no usable report` rather than an auth error.
- `feat(config)` — fast jury raised to Luna `max` + DeepSeek `high`.

Bumps `package.json`, `package-lock.json`, and `src/cli.ts`.

**Known issue, documented in #6 and not fixed here:** Luna at `max` collides with the 900s `per_model_timeout_seconds` — one hard timeout in a 10-PR benchmark (#10335, zero findings published) plus two runs within 17% of the wall. Raising that global to ~1800s is the fix.