### PR TITLE
fix(config): raise the per-model timeout wall to 1800s (v1.2.1)

### DIFF
--- a/.juror.yml
+++ b/.juror.yml
@@ -66,7 +66,7 @@ review:
   anchor_tolerance: 3
 
   max_diff_bytes: 400000 # larger diffs are truncated, and the summary says so
-  per_model_timeout_seconds: 900 # hard wall-clock kill per model
+  per_model_timeout_seconds: 1800 # hard wall-clock kill per model, not a latency target
   max_turns: 0 # no step cap; per_model_timeout_seconds remains the hard boundary
 
 budget:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juror-ai",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juror-ai",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juror-ai",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Multi-model PR review that shows you the bill. Duplicate findings collapse into one, with optional agreement filtering.",
   "license": "MIT",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ import { checkoutAt, type EphemeralCheckout } from './util/worktree.js';
 import { evaluateBenchmark, parseBenchmarkCorpus, renderBenchmark } from './benchmark.js';
 import { loadAgentInstructions } from './instructions.js';
 
-export const VERSION = '1.2.0';
+export const VERSION = '1.2.1';
 
 const USAGE = `
 juror ${VERSION} — multi-model PR review that shows you the bill

--- a/src/config.ts
+++ b/src/config.ts
@@ -230,7 +230,11 @@ export function defaultConfig(): JurorConfig {
       ],
       anchor_tolerance: 3,
       max_diff_bytes: 400_000,
-      per_model_timeout_seconds: 900,
+      // Measured against the default `fast` jury: Luna at `max` reasoning needs 750–900s on
+      // a large diff, so the old 900s wall killed roughly one review in ten mid-flight and
+      // published nothing from that model. This is a kill switch for a hung harness, not a
+      // latency target — set it above the slowest legitimate run, not near it.
+      per_model_timeout_seconds: 1800,
       // Zero means unlimited. The wall-clock timeout remains the hard safety boundary;
       // positive values are still accepted for users who want an explicit agent-step cap.
       max_turns: 0,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -54,6 +54,9 @@ describe('defaultConfig', () => {
     expect(c.models[1]?.args?.['variant']).toBe('high');
     expect(c.consensus.verify_model).toBe('deepseek-v4-flash-0731');
     expect(c.consensus.referee_model).toBe('deepseek-v4-flash-0731');
+    // Luna at `max` was measured at 750–900s on large diffs. The wall must clear that with
+    // room to spare, or the default jury loses a model mid-review on big PRs.
+    expect(c.review.per_model_timeout_seconds).toBe(1800);
   });
 
   it('hands out an independent copy each call', () => {


### PR DESCRIPTION
Follow-up to the known issue documented in #6 and in the v1.2.0 release notes.

## The problem

v1.2.0 moved the default `fast` jury to Luna at `max` reasoning **without moving the wall that kills it.** `per_model_timeout_seconds` stayed at 900s, which was sized for `low`.

Measured across the 10-PR benchmark:

| PR | Luna wall-clock | Result |
|---|---|---|
| #10335 | 900s | **killed, published nothing** |
| #10301 | 813s | 90% of the wall |
| #10300 | 751s | 83% of the wall |

One hard failure in ten, two near-misses. On #10335 the review completed and reported success while silently missing half its jury.

## The change

`per_model_timeout_seconds` 900 → 1800.

This value is a **kill switch for a hung harness, not a latency target.** A run that finishes early costs nothing extra — models are billed for what they consume, and each still stops at the first of its own `timeout_seconds` override or the budget ceiling. Doubling the wall does not make any review slower; it only stops a legitimate slow run from being destroyed at the finish line.

Anyone who wants the old behaviour can set it back:

```yaml
review:
  per_model_timeout_seconds: 900
```

## Scope

This is a global default, so it applies to all four presets — deliberate. `balanced` runs Terra at `max` and `ultra` runs seven models including three Codex ones, so they sit under the same wall and benefit identically.

Adds a test pinning the default, so it cannot drift back below the reasoning effort the default preset ships.

Version bumped to 1.2.1 in this PR rather than a separate release PR, matching the v1.1.0 convention.

## Verification

`npm run typecheck`, `npm run build`, `npm test` — 329 tests across 27 files, all passing. Confirmed the built artifact resolves to `timeout: 1800 | luna: max | deepseek: high`.