### PR TITLE
feat(config): read provider keys from JUROR_-prefixed variables (v1.3.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,16 @@
 # Copy to .env and fill in. .env is gitignored — never commit real keys.
-ANTHROPIC_API_KEY=
-OPENAI_API_KEY=
-XAI_API_KEY=
-FIREWORKS_API_KEY=
+#
+# Prefixed names are preferred. Give Juror its OWN provider key rather than reusing the
+# one your other tools use: review spend then shows up as a separate line in provider
+# billing, and you can rotate or cap it without touching anything else.
+JUROR_ANTHROPIC_API_KEY=
+JUROR_OPENAI_API_KEY=
+JUROR_XAI_API_KEY=
+JUROR_FIREWORKS_API_KEY=
+
+# The unprefixed vendor names still work as a fallback, so an existing setup keeps
+# running unchanged. A prefixed key always wins when both are set.
+# ANTHROPIC_API_KEY=
+# OPENAI_API_KEY=
+# XAI_API_KEY=
+# FIREWORKS_API_KEY=

--- a/.github/workflows/juror.yml
+++ b/.github/workflows/juror.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-          FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+          JUROR_ANTHROPIC_API_KEY: ${{ secrets.JUROR_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY }}
+          JUROR_OPENAI_API_KEY: ${{ secrets.JUROR_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
+          JUROR_XAI_API_KEY: ${{ secrets.JUROR_XAI_API_KEY || secrets.XAI_API_KEY }}
+          JUROR_FIREWORKS_API_KEY: ${{ secrets.JUROR_FIREWORKS_API_KEY || secrets.FIREWORKS_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -48,19 +48,24 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         env:
-          OPENAI_API_KEY:    ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          XAI_API_KEY:       ${{ secrets.XAI_API_KEY }}
-          FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+          JUROR_OPENAI_API_KEY:    ${{ secrets.JUROR_OPENAI_API_KEY }}
+          JUROR_ANTHROPIC_API_KEY: ${{ secrets.JUROR_ANTHROPIC_API_KEY }}
+          JUROR_XAI_API_KEY:       ${{ secrets.JUROR_XAI_API_KEY }}
+          JUROR_FIREWORKS_API_KEY: ${{ secrets.JUROR_FIREWORKS_API_KEY }}
 ```
 
 **2 — Add at least one provider key.** *Settings → Secrets and variables → Actions*, or from
 your terminal:
 
 ```bash
-gh secret set OPENAI_API_KEY      # one key is enough to start
-gh secret set ANTHROPIC_API_KEY   # every extra key adds another juror
+gh secret set JUROR_OPENAI_API_KEY      # one key is enough to start
+gh secret set JUROR_ANTHROPIC_API_KEY   # every extra key adds another juror
 ```
+
+Issue Juror its **own** provider key rather than reusing an existing one. Review spend then
+appears as its own line in provider billing, and you can rotate or cap it without touching
+anything else you run. The unprefixed names (`OPENAI_API_KEY`, …) still work as a fallback,
+so an existing install keeps running; a prefixed key wins when both are set.
 
 Any key you leave out is skipped with a note in the receipt. One key gets you a working
 single-model review; four gets you the full jury. Degrade, never fail.
@@ -76,7 +81,7 @@ That's the whole setup — `.juror.yml` is optional, and every default is listed
 Same binary, same code path, nothing posted unless you ask:
 
 ```bash
-export OPENAI_API_KEY=…
+export JUROR_OPENAI_API_KEY=…
 npx juror-ai review --pr 1234 --repo owner/name          # prints to your terminal
 npx juror-ai review --pr 1234 --repo owner/name --post   # ...and posts it
 ```
@@ -218,10 +223,10 @@ Juror copies only committed/staged/tracked working changes into a detached model
 so this untracked file is not inside any reviewer read root:
 
 ```
-ANTHROPIC_API_KEY=…
-OPENAI_API_KEY=…
-FIREWORKS_API_KEY=…
-XAI_API_KEY=…
+JUROR_ANTHROPIC_API_KEY=…
+JUROR_OPENAI_API_KEY=…
+JUROR_FIREWORKS_API_KEY=…
+JUROR_XAI_API_KEY=…
 ```
 
 ---
@@ -249,7 +254,7 @@ models:
     harness: opencode
     harness_model: fireworks-ai/accounts/fireworks/models/deepseek-v4-flash-0731
     pricing_key: accounts/fireworks/models/deepseek-v4-flash-0731
-    secret: FIREWORKS_API_KEY
+    secret: JUROR_FIREWORKS_API_KEY
     args: { variant: high }
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,10 @@ runs:
     - name: Set up Node
       uses: actions/setup-node@v4
       env:
+        JUROR_ANTHROPIC_API_KEY: ''
+        JUROR_OPENAI_API_KEY: ''
+        JUROR_FIREWORKS_API_KEY: ''
+        JUROR_XAI_API_KEY: ''
         ANTHROPIC_API_KEY: ''
         OPENAI_API_KEY: ''
         FIREWORKS_API_KEY: ''
@@ -76,6 +80,10 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       env:
+        JUROR_ANTHROPIC_API_KEY: ''
+        JUROR_OPENAI_API_KEY: ''
+        JUROR_FIREWORKS_API_KEY: ''
+        JUROR_XAI_API_KEY: ''
         ANTHROPIC_API_KEY: ''
         OPENAI_API_KEY: ''
         FIREWORKS_API_KEY: ''
@@ -97,12 +105,18 @@ runs:
         KIMI_CODE_SPEC: ${{ inputs.kimi-code-version }}
       run: |
         set -euo pipefail
-        CLEAN_ENV=(env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u FIREWORKS_API_KEY -u XAI_API_KEY -u GITHUB_TOKEN -u GH_TOKEN)
-        [ -n "${ANTHROPIC_API_KEY:-}" ] && "${CLEAN_ENV[@]}" npm i -g "$CLAUDE_CODE_SPEC" || true
-        [ -n "${OPENAI_API_KEY:-}"    ] && "${CLEAN_ENV[@]}" npm i -g "$CODEX_SPEC"       || true
-        [ -n "${FIREWORKS_API_KEY:-}" ] && "${CLEAN_ENV[@]}" npm i -g "$OPENCODE_SPEC"    || true
-        [ -n "${FIREWORKS_API_KEY:-}" ] && "${CLEAN_ENV[@]}" npm i -g "$KIMI_CODE_SPEC"   || true
-        if [ -n "${XAI_API_KEY:-}" ]; then
+        # A prefixed key wins, the bare vendor name is the pre-1.3 fallback. Gating on the
+        # resolved value keeps a harness from being installed for a provider with no key.
+        HAS_ANTHROPIC="${JUROR_ANTHROPIC_API_KEY:-${ANTHROPIC_API_KEY:-}}"
+        HAS_OPENAI="${JUROR_OPENAI_API_KEY:-${OPENAI_API_KEY:-}}"
+        HAS_FIREWORKS="${JUROR_FIREWORKS_API_KEY:-${FIREWORKS_API_KEY:-}}"
+        HAS_XAI="${JUROR_XAI_API_KEY:-${XAI_API_KEY:-}}"
+        CLEAN_ENV=(env -u JUROR_ANTHROPIC_API_KEY -u JUROR_OPENAI_API_KEY -u JUROR_FIREWORKS_API_KEY -u JUROR_XAI_API_KEY -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u FIREWORKS_API_KEY -u XAI_API_KEY -u GITHUB_TOKEN -u GH_TOKEN)
+        [ -n "$HAS_ANTHROPIC" ] && "${CLEAN_ENV[@]}" npm i -g "$CLAUDE_CODE_SPEC" || true
+        [ -n "$HAS_OPENAI"    ] && "${CLEAN_ENV[@]}" npm i -g "$CODEX_SPEC"       || true
+        [ -n "$HAS_FIREWORKS" ] && "${CLEAN_ENV[@]}" npm i -g "$OPENCODE_SPEC"    || true
+        [ -n "$HAS_FIREWORKS" ] && "${CLEAN_ENV[@]}" npm i -g "$KIMI_CODE_SPEC"   || true
+        if [ -n "$HAS_XAI" ]; then
           "${CLEAN_ENV[@]}" curl -fsSL https://grok.com/install.sh | "${CLEAN_ENV[@]}" bash || true
         fi
         echo "$HOME/.grok/bin" >> "$GITHUB_PATH"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juror-ai",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juror-ai",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juror-ai",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Multi-model PR review that shows you the bill. Duplicate findings collapse into one, with optional agreement filtering.",
   "license": "MIT",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import {
   loadConfig,
   loadConfigText,
   parseReviewPreset,
+  readSecret,
   resolveModelRuntime,
   REVIEW_PRESETS,
 } from './config.js';
@@ -38,7 +39,7 @@ import { checkoutAt, type EphemeralCheckout } from './util/worktree.js';
 import { evaluateBenchmark, parseBenchmarkCorpus, renderBenchmark } from './benchmark.js';
 import { loadAgentInstructions } from './instructions.js';
 
-export const VERSION = '1.2.1';
+export const VERSION = '1.3.0';
 
 const USAGE = `
 juror ${VERSION} — multi-model PR review that shows you the bill
@@ -72,7 +73,10 @@ Options
   -h, --help             This message
 
 Environment
-  ANTHROPIC_API_KEY  OPENAI_API_KEY  XAI_API_KEY  FIREWORKS_API_KEY
+  JUROR_ANTHROPIC_API_KEY  JUROR_OPENAI_API_KEY  JUROR_XAI_API_KEY  JUROR_FIREWORKS_API_KEY
+  The unprefixed names (ANTHROPIC_API_KEY, …) still work as a fallback. Prefer the
+  prefixed ones and give Juror its own provider key, so review spend is billed and
+  tracked separately from everything else that account does.
   GITHUB_TOKEN
   Any model whose key is absent is skipped with a note in the receipt — a repo with one
   key still gets a working review.
@@ -569,7 +573,7 @@ function runnableModelLabels(
   const wanted = new Set(onlyModels.map((id) => id.trim()).filter(Boolean));
   return config.models
     .filter((model) => model.enabled && (wanted.size === 0 || wanted.has(model.id)))
-    .filter((model) => Boolean(secrets[model.secret]?.trim()))
+    .filter((model) => Boolean(readSecret(secrets, model.secret).value))
     .map((model) => resolveModelRuntime(model).label);
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,11 +30,14 @@ const HARNESS_IDS: readonly HarnessId[] = [
 ];
 
 /**
- * The env var each harness reads by default. Having this table is what lets a user add a
- * model with two lines (`id` + `harness`) instead of remembering which provider key the
- * CLI underneath happens to want.
+ * Two different names are in play for one key, and conflating them breaks authentication
+ * silently — the failure looks like "the model returned nothing", not like an auth error.
+ *
+ * `PROVIDER_ENV` is the variable the vendor CLI reads for itself. Claude Code, opencode,
+ * and Grok are handed their environment directly, so these names are fixed by the vendors
+ * and are NOT ours to rename.
  */
-const DEFAULT_SECRET: Record<HarnessId, string> = {
+const PROVIDER_ENV: Record<HarnessId, string> = {
   'claude-code': 'ANTHROPIC_API_KEY',
   codex: 'OPENAI_API_KEY',
   'grok-build': 'XAI_API_KEY',
@@ -42,6 +45,52 @@ const DEFAULT_SECRET: Record<HarnessId, string> = {
   opencode: 'FIREWORKS_API_KEY',
   'generic-openai': 'OPENAI_API_KEY',
 };
+
+/** The vendor variable a harness hands to its CLI. Never a `JUROR_`-prefixed name. */
+export function providerEnvFor(harness: HarnessId): string {
+  return PROVIDER_ENV[harness];
+}
+
+export const JUROR_SECRET_PREFIX = 'JUROR_';
+
+/**
+ * `DEFAULT_SECRET` is the variable JUROR reads from the operator, and it is deliberately
+ * prefixed. Pointing Juror at `JUROR_OPENAI_API_KEY` lets an operator issue it a dedicated
+ * provider key, so review spend shows up as its own line in provider billing instead of
+ * being mixed into whatever else that account does.
+ *
+ * Having this table is what lets a user add a model with two lines (`id` + `harness`)
+ * instead of remembering which provider key the CLI underneath happens to want.
+ */
+const DEFAULT_SECRET: Record<HarnessId, string> = {
+  'claude-code': 'JUROR_ANTHROPIC_API_KEY',
+  codex: 'JUROR_OPENAI_API_KEY',
+  'grok-build': 'JUROR_XAI_API_KEY',
+  'kimi-code': 'JUROR_FIREWORKS_API_KEY',
+  opencode: 'JUROR_FIREWORKS_API_KEY',
+  'generic-openai': 'JUROR_OPENAI_API_KEY',
+};
+
+/**
+ * Read a model's key, preferring the prefixed name and falling back to the bare vendor one.
+ *
+ * The fallback is what keeps every pre-1.3 install working: an operator who set only
+ * `OPENAI_API_KEY` keeps a working review and can migrate whenever they like. Returns the
+ * name it actually read from so callers can say which variable satisfied the model.
+ */
+export function readSecret(
+  env: Record<string, string | undefined>,
+  secretName: string,
+): { value: string | undefined; source: string } {
+  const direct = env[secretName];
+  if (typeof direct === 'string' && direct.trim()) return { value: direct, source: secretName };
+  if (secretName.startsWith(JUROR_SECRET_PREFIX)) {
+    const bare = secretName.slice(JUROR_SECRET_PREFIX.length);
+    const legacy = env[bare];
+    if (typeof legacy === 'string' && legacy.trim()) return { value: legacy, source: bare };
+  }
+  return { value: undefined, source: secretName };
+}
 
 /** Credentials that are privileged control-plane tokens, never model-provider inputs. */
 const RESERVED_MODEL_SECRETS = new Set([
@@ -63,14 +112,14 @@ const BUILTIN_MODELS: Record<string, ModelConfig> = {
     id: 'claude-opus-5',
     harness: 'claude-code',
     enabled: true,
-    secret: 'ANTHROPIC_API_KEY',
+    secret: 'JUROR_ANTHROPIC_API_KEY',
     label: 'Opus 5',
   },
   'gpt-5.6-sol': {
     id: 'gpt-5.6-sol',
     harness: 'codex',
     enabled: true,
-    secret: 'OPENAI_API_KEY',
+    secret: 'JUROR_OPENAI_API_KEY',
     label: 'GPT-5.6 Sol',
     args: { reasoning_effort: 'high' },
   },
@@ -78,7 +127,7 @@ const BUILTIN_MODELS: Record<string, ModelConfig> = {
     id: 'gpt-5.6-terra',
     harness: 'codex',
     enabled: true,
-    secret: 'OPENAI_API_KEY',
+    secret: 'JUROR_OPENAI_API_KEY',
     label: 'GPT-5.6 Terra',
     args: { reasoning_effort: 'max' },
   },
@@ -86,7 +135,7 @@ const BUILTIN_MODELS: Record<string, ModelConfig> = {
     id: 'gpt-5.6-luna',
     harness: 'codex',
     enabled: true,
-    secret: 'OPENAI_API_KEY',
+    secret: 'JUROR_OPENAI_API_KEY',
     label: 'GPT-5.6 Luna',
     args: { reasoning_effort: 'low' },
   },
@@ -94,7 +143,7 @@ const BUILTIN_MODELS: Record<string, ModelConfig> = {
     id: 'grok-4.5',
     harness: 'grok-build',
     enabled: true,
-    secret: 'XAI_API_KEY',
+    secret: 'JUROR_XAI_API_KEY',
     label: 'Grok 4.5',
     args: { reasoning_effort: 'high' },
   },
@@ -102,7 +151,7 @@ const BUILTIN_MODELS: Record<string, ModelConfig> = {
     id: 'kimi-k3',
     harness: 'kimi-code',
     enabled: true,
-    secret: 'FIREWORKS_API_KEY',
+    secret: 'JUROR_FIREWORKS_API_KEY',
     label: 'Kimi K3',
     base_url: 'https://api.fireworks.ai/inference/v1',
     harness_model: 'accounts/fireworks/models/kimi-k3',
@@ -113,7 +162,7 @@ const BUILTIN_MODELS: Record<string, ModelConfig> = {
     id: 'deepseek-v4-flash-0731',
     harness: 'opencode',
     enabled: true,
-    secret: 'FIREWORKS_API_KEY',
+    secret: 'JUROR_FIREWORKS_API_KEY',
     label: 'DeepSeek V4 Flash',
     harness_model: 'fireworks-ai/accounts/fireworks/models/deepseek-v4-flash-0731',
     pricing_key: 'accounts/fireworks/models/deepseek-v4-flash-0731',

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -23,7 +23,7 @@ import type {
 } from '../types.js';
 import { log } from '../util/log.js';
 import { run } from '../util/proc.js';
-import { renderTemplate, resolveModelRuntime } from '../config.js';
+import { providerEnvFor, readSecret, renderTemplate, resolveModelRuntime } from '../config.js';
 import { computeCost } from '../cost/compute.js';
 import { getHarness } from './registry.js';
 import { runGenericOpenAI } from './generic-openai.js';
@@ -225,7 +225,7 @@ function envPassthrough(m: ModelConfig): string[] {
 export async function fanOut(o: FanOutOptions): Promise<ModelRun[]> {
   const ambient: Record<string, string | undefined> = process.env;
   const enabled = o.config.models.filter((m) => m.enabled);
-  const runnable = enabled.filter((m) => hasKey(o.secrets[m.secret]));
+  const runnable = enabled.filter((m) => hasKey(readSecret(o.secrets, m.secret).value));
   const budgetUsd = perModelTarget(o.config.budget.target_cost_usd_per_pr, runnable.length);
 
   log.debug(
@@ -257,7 +257,7 @@ async function runOne(
     const h = getHarness(m.harness);
     harnessLabel = h.label;
 
-    const key = o.secrets[m.secret];
+    const { value: key } = readSecret(o.secrets, m.secret);
     if (!hasKey(key)) {
       log.info(`${modelLabel}: skipped (no ${m.secret})`);
       return {
@@ -276,7 +276,10 @@ async function runOne(
       };
     }
 
-    const modelEnv = childEnv(ambient, m.secret, key, envPassthrough(m));
+    // The child is handed the VENDOR variable, never the `JUROR_`-prefixed one Juror read
+    // it from: Claude Code, opencode, and Grok authenticate from their own environment, so
+    // a prefixed name here would leave them unauthenticated with no visible auth error.
+    const modelEnv = childEnv(ambient, providerEnvFor(m.harness), key, envPassthrough(m));
 
     const scratchDir = harnessScratch(o.scratchRoot, m.id, ordinal);
     await mkdir(scratchDir, { recursive: true });

--- a/src/merge/referee.ts
+++ b/src/merge/referee.ts
@@ -18,7 +18,7 @@ import type {
   PricingTable,
   RunContext,
 } from '../types.js';
-import { renderTemplate, resolveModelRuntime } from '../config.js';
+import { providerEnvFor, readSecret, renderTemplate, resolveModelRuntime } from '../config.js';
 import { computeCost } from '../cost/compute.js';
 import { getHarness } from '../harness/registry.js';
 import { runHarness } from '../harness/runner.js';
@@ -258,7 +258,7 @@ function childEnv(m: ModelConfig, secret: string): Record<string, string> {
     if (typeof v === 'string') env[name] = v;
   }
   // Exactly one provider key, same rule as fan-out.
-  env[m.secret] = secret;
+  env[providerEnvFor(m.harness)] = secret;
   return env;
 }
 
@@ -501,7 +501,7 @@ export async function refereeClusters(
     return { clusters, cost: { ...ZERO_COST }, calls: 0 };
   }
 
-  const key = o.secrets[m.secret];
+  const { value: key } = readSecret(o.secrets, m.secret);
   if (!hasKey(key)) {
     log.info(`referee: skipped (no ${m.secret})`);
     return { clusters, cost: { ...ZERO_COST }, calls: 0 };

--- a/src/merge/verify.ts
+++ b/src/merge/verify.ts
@@ -20,7 +20,7 @@ import type {
   RunContext,
   Verification,
 } from '../types.js';
-import { renderTemplate, resolveModelRuntime } from '../config.js';
+import { providerEnvFor, readSecret, renderTemplate, resolveModelRuntime } from '../config.js';
 import { computeCost } from '../cost/compute.js';
 import { getHarness } from '../harness/registry.js';
 import { runHarness } from '../harness/runner.js';
@@ -227,7 +227,7 @@ function childEnv(m: ModelConfig, secret: string): Record<string, string> {
     const v = process.env[name];
     if (typeof v === 'string') env[name] = v;
   }
-  env[m.secret] = secret;
+  env[providerEnvFor(m.harness)] = secret;
   return env;
 }
 
@@ -427,7 +427,7 @@ export async function verifyClusters(clusters: Cluster[], o: VerifyOptions): Pro
   const m = o.modelRun;
   if (!m) return { clusters, cost: { ...ZERO_COST }, calls: 0 };
 
-  const key = o.secrets[m.secret];
+  const { value: key } = readSecret(o.secrets, m.secret);
   if (!hasKey(key)) {
     log.info(`verify: skipped (no ${m.secret})`);
     return { clusters, cost: { ...ZERO_COST }, calls: 0 };

--- a/src/review.ts
+++ b/src/review.ts
@@ -31,7 +31,7 @@ import { applyPublishRules, requiredAgreement, scoreReview } from './merge/score
 import { loadPricing, totalCost } from './cost/compute.js';
 import { fanOut } from './harness/runner.js';
 import { synthesizeSummary } from './render/summary.js';
-import { loadPromptTemplate, renderTemplate, resolveModelRuntime } from './config.js';
+import { loadPromptTemplate, readSecret, renderTemplate, resolveModelRuntime } from './config.js';
 import { loadAgentInstructions } from './instructions.js';
 import type { LoadedAgentInstructions } from './instructions.js';
 import { log } from './util/log.js';
@@ -114,7 +114,7 @@ export async function runReview(o: ReviewOptions): Promise<ReviewResult> {
       log.warn(msg);
     }
 
-    if (!enabled.some((model) => hasSecret(o.secrets[model.secret]))) {
+    if (!enabled.some((model) => hasSecret(readSecret(o.secrets, model.secret).value))) {
       return emptyResult(o.diff, started, [...warnings, 'No runnable model fits the spend target.']);
     }
 
@@ -394,7 +394,7 @@ function planModelsWithinTarget(
   pricing: ReturnType<typeof loadPricing>,
   warnings: string[],
 ): { config: JurorConfig; estimate: number } | null {
-  const runnable = config.models.filter((m) => m.enabled && hasSecret(secrets[m.secret]));
+  const runnable = config.models.filter((m) => m.enabled && hasSecret(readSecret(secrets, m.secret).value));
   const estimate = estimateReviewCost(diff, runnable, pricing);
   const target = config.budget.target_cost_usd_per_pr;
   if (estimate <= target) return { config, estimate };
@@ -415,7 +415,7 @@ function planModelsWithinTarget(
   }
 
   const models = config.models.map((model) => {
-    if (!model.enabled || !hasSecret(secrets[model.secret]) || selected.has(model.id)) return model;
+    if (!model.enabled || !hasSecret(readSecret(secrets, model.secret).value) || selected.has(model.id)) return model;
     warnings.push(`${model.label ?? model.id} omitted because its estimate does not fit the spend target.`);
     return { ...model, enabled: false };
   });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -9,6 +9,8 @@ import {
   loadConfig,
   loadConfigText,
   loadPromptTemplate,
+  providerEnvFor,
+  readSecret,
   renderTemplate,
   resolveModelRuntime,
 } from '../src/config.js';
@@ -42,10 +44,10 @@ describe('defaultConfig', () => {
     expect(c.consensus.min_agreement).toBe('all');
     expect(c.models.map((m) => m.id)).toEqual(['gpt-5.6-luna', 'deepseek-v4-flash-0731']);
     expect(c.models[0]?.harness).toBe('codex');
-    expect(c.models[0]?.secret).toBe('OPENAI_API_KEY');
+    expect(c.models[0]?.secret).toBe('JUROR_OPENAI_API_KEY');
     expect(c.models[0]?.args?.['reasoning_effort']).toBe('max');
     expect(c.models[1]?.harness).toBe('opencode');
-    expect(c.models[1]?.secret).toBe('FIREWORKS_API_KEY');
+    expect(c.models[1]?.secret).toBe('JUROR_FIREWORKS_API_KEY');
     expect(c.models[1]?.harness_model).toBe(
       'fireworks-ai/accounts/fireworks/models/deepseek-v4-flash-0731',
     );
@@ -101,6 +103,52 @@ describe('defaultConfig', () => {
   });
 });
 
+describe('provider credentials', () => {
+  it('prefers the prefixed name so Juror spend can be billed separately', () => {
+    const env = { JUROR_OPENAI_API_KEY: 'dedicated', OPENAI_API_KEY: 'shared' };
+    expect(readSecret(env, 'JUROR_OPENAI_API_KEY')).toEqual({
+      value: 'dedicated',
+      source: 'JUROR_OPENAI_API_KEY',
+    });
+  });
+
+  // Without this every pre-1.3 install silently loses its whole jury on upgrade.
+  it('falls back to the bare vendor name, and reports which one it read', () => {
+    expect(readSecret({ OPENAI_API_KEY: 'shared' }, 'JUROR_OPENAI_API_KEY')).toEqual({
+      value: 'shared',
+      source: 'OPENAI_API_KEY',
+    });
+  });
+
+  it('treats a blank or missing key as absent rather than as a value', () => {
+    expect(readSecret({ JUROR_OPENAI_API_KEY: '   ' }, 'JUROR_OPENAI_API_KEY').value).toBeUndefined();
+    expect(readSecret({}, 'JUROR_OPENAI_API_KEY').value).toBeUndefined();
+    // A blank prefixed key must not shadow a real bare one.
+    expect(readSecret({ JUROR_OPENAI_API_KEY: '', OPENAI_API_KEY: 'shared' }, 'JUROR_OPENAI_API_KEY').value).toBe(
+      'shared',
+    );
+  });
+
+  it('does not invent a fallback for a custom secret name', () => {
+    expect(readSecret({ MY_KEY: 'k' }, 'MY_KEY').value).toBe('k');
+    expect(readSecret({ KEY: 'k' }, 'MY_KEY').value).toBeUndefined();
+  });
+
+  // Claude Code, opencode and Grok read their own environment, so the name handed to the
+  // child is fixed by the vendor. Renaming it there is an invisible 401, not a config error.
+  it('hands every harness the vendor variable, never the prefixed one', () => {
+    expect(providerEnvFor('claude-code')).toBe('ANTHROPIC_API_KEY');
+    expect(providerEnvFor('codex')).toBe('OPENAI_API_KEY');
+    expect(providerEnvFor('grok-build')).toBe('XAI_API_KEY');
+    expect(providerEnvFor('kimi-code')).toBe('FIREWORKS_API_KEY');
+    expect(providerEnvFor('opencode')).toBe('FIREWORKS_API_KEY');
+    expect(providerEnvFor('generic-openai')).toBe('OPENAI_API_KEY');
+    for (const harness of ['claude-code', 'codex', 'grok-build', 'kimi-code', 'opencode', 'generic-openai'] as const) {
+      expect(providerEnvFor(harness).startsWith('JUROR_')).toBe(false);
+    }
+  });
+});
+
 describe('loadConfig', () => {
   it('returns the defaults with no problems when there is no config file', () => {
     const { config, problems, sourcePath } = loadConfig(repoWith({}));
@@ -141,7 +189,7 @@ describe('loadConfig', () => {
       'models:\n  - id: custom\n    harness: generic-openai\n    secret: GITHUB_TOKEN\n',
       '.juror.yml@base',
     );
-    expect(loaded.config.models[0]?.secret).toBe('OPENAI_API_KEY');
+    expect(loaded.config.models[0]?.secret).toBe('JUROR_OPENAI_API_KEY');
     expect(loaded.problems.join('\n')).toContain('not permitted for a model process');
   });
 
@@ -260,7 +308,7 @@ describe('loadConfig', () => {
     expect(config.consensus.referee_model).toBe('claude-opus-5');
     // `enabled` and `secret` come from the per-harness default so they can be omitted.
     expect(config.models[0]?.enabled).toBe(true);
-    expect(config.models[0]?.secret).toBe('ANTHROPIC_API_KEY');
+    expect(config.models[0]?.secret).toBe('JUROR_ANTHROPIC_API_KEY');
   });
 
   it('defaults every Kimi Code model to the Fireworks credential', () => {
@@ -269,7 +317,7 @@ describe('loadConfig', () => {
     });
     const { config, problems } = loadConfig(dir);
     expect(problems).toEqual([]);
-    expect(config.models[0]?.secret).toBe('FIREWORKS_API_KEY');
+    expect(config.models[0]?.secret).toBe('JUROR_FIREWORKS_API_KEY');
   });
 
   it('drops a model with an unknown harness and keeps its siblings', () => {


### PR DESCRIPTION
Juror read the same `OPENAI_API_KEY` everything else on the runner uses, so its spend was indistinguishable from the rest of that account's usage. It now reads `JUROR_OPENAI_API_KEY` and friends, so an operator can issue it a **dedicated provider key** that bills, rotates, and caps on its own.

```yaml
env:
  JUROR_OPENAI_API_KEY:    ${{ secrets.JUROR_OPENAI_API_KEY }}
  JUROR_ANTHROPIC_API_KEY: ${{ secrets.JUROR_ANTHROPIC_API_KEY }}
  JUROR_XAI_API_KEY:       ${{ secrets.JUROR_XAI_API_KEY }}
  JUROR_FIREWORKS_API_KEY: ${{ secrets.JUROR_FIREWORKS_API_KEY }}
```

## The part that makes this non-trivial

A naive rename **silently breaks authentication for three of the six harnesses.**

Claude Code, opencode, and Grok are handed their environment directly and authenticate from the vendor's own variable name. Rename what the child receives and they send no credential — which surfaces as *"the model returned nothing"*, not as an auth error. That is exactly the failure that disabled every Codex model through v1.1.0.

So there are now two distinct names for one key:

| | Meaning | Example |
|---|---|---|
| `secret` | what **Juror** reads from the operator | `JUROR_OPENAI_API_KEY` |
| `providerEnvFor(harness)` | what the **vendor CLI** reads for itself | `OPENAI_API_KEY` |

Only the operator-facing input is renamed. Child processes still receive the bare vendor variable, and a test asserts no harness is ever handed a `JUROR_`-prefixed name.

## Backward compatibility

**Non-breaking.** Unprefixed names remain a working fallback via `readSecret()`, so every existing install keeps running and can migrate whenever it likes. A prefixed key wins when both are set, and a blank prefixed key does not shadow a real bare one.

The Action gates harness installation on the resolved value, so a provider with no key under either name still installs nothing.

## Verification

Unit tests are not sufficient for a credential path — the last bug here typechecked and unit-tested fine. Verified **live** against `textcortex/platform#10317`:

- **Prefixed only** (bare names unset in the process env): both models authenticated and billed real tokens — Codex 7.8M in / 65.3k out / $0.37, opencode 1.8M in / 34.2k out / $0.08, 6 findings published. Covers both auth mechanisms: Codex's `auth.json` and opencode's vendor env var.
- **Bare only** (prefixed unset): both models still selected and started, confirming the fallback.

`npm run typecheck`, `npm run build`, `npm test` — 334 tests across 27 files (5 new, covering precedence, blank-key shadowing, custom secret names, and the vendor-name decoupling).

Version bumped to 1.3.0 in this PR.