### PR TITLE
fix(config): drop the fast jury's Luna to high reasoning (v1.3.1)

### DIFF
--- a/.juror.yml
+++ b/.juror.yml
@@ -10,7 +10,7 @@ version: 1
 # Built-in jury selection: fast | balanced | high | ultra. Missing provider keys simply
 # skip their models. `models:` can replace the selected preset with a fully custom jury.
 #
-# fast (default):     GPT-5.6 Luna max + DeepSeek V4 Flash high
+# fast (default):     GPT-5.6 Luna high + DeepSeek V4 Flash high
 # balanced:           GPT-5.6 Terra max + Grok 4.5 high + Kimi K3
 # high:               GPT-5.6 Sol + Opus 5 + Grok 4.5
 # ultra:              every model above, using the higher reasoning settings

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Juror ships four jury presets. Models whose provider key is unavailable are skip
 
 | Preset | Jury | Intended use |
 |---|---|---|
-| `fast` **(default)** | GPT-5.6 Luna via Codex/OpenAI (`max`) · DeepSeek V4 Flash via opencode/Fireworks (`high`) | Smallest, cheapest jury |
+| `fast` **(default)** | GPT-5.6 Luna via Codex/OpenAI (`high`) · DeepSeek V4 Flash via opencode/Fireworks (`high`) | Smallest, cheapest jury |
 | `balanced` | GPT-5.6 Terra via Codex/OpenAI (`max`) · Grok 4.5 via Grok Build/xAI (`high`) · Kimi K3 via Kimi Code/Fireworks (`max`) | Strong provider diversity without the full burn |
 | `high` | GPT-5.6 Sol via Codex/OpenAI (`high`) · Opus 5 via Claude Code/Anthropic · Grok 4.5 via Grok Build/xAI (`high`) | Higher-confidence frontier jury |
 | `ultra` | Every model from the other presets (seven total), using their higher reasoning settings | Maximum coverage; highest token and cost use |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juror-ai",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juror-ai",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juror-ai",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Multi-model PR review that shows you the bill. Duplicate findings collapse into one, with optional agreement filtering.",
   "license": "MIT",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,7 @@ import { checkoutAt, type EphemeralCheckout } from './util/worktree.js';
 import { evaluateBenchmark, parseBenchmarkCorpus, renderBenchmark } from './benchmark.js';
 import { loadAgentInstructions } from './instructions.js';
 
-export const VERSION = '1.3.0';
+export const VERSION = '1.3.1';
 
 const USAGE = `
 juror ${VERSION} — multi-model PR review that shows you the bill

--- a/src/config.ts
+++ b/src/config.ts
@@ -181,7 +181,7 @@ const PRESET_DEFINITIONS: Record<ReviewPreset, PresetDefinition> = {
     modelIds: ['gpt-5.6-luna', 'deepseek-v4-flash-0731'],
     consensusModel: 'deepseek-v4-flash-0731',
     args: {
-      'gpt-5.6-luna': { reasoning_effort: 'max' },
+      'gpt-5.6-luna': { reasoning_effort: 'high' },
       'deepseek-v4-flash-0731': { variant: 'high' },
     },
   },
@@ -279,10 +279,12 @@ export function defaultConfig(): JurorConfig {
       ],
       anchor_tolerance: 3,
       max_diff_bytes: 400_000,
-      // Measured against the default `fast` jury: Luna at `max` reasoning needs 750–900s on
-      // a large diff, so the old 900s wall killed roughly one review in ten mid-flight and
-      // published nothing from that model. This is a kill switch for a hung harness, not a
-      // latency target — set it above the slowest legitimate run, not near it.
+      // Measured against the default `fast` jury: Luna needed 750–900s on a large diff at
+      // `max` reasoning, so the old 900s wall killed roughly one review in ten mid-flight
+      // and published nothing from that model. The jury now runs `high`, which is faster,
+      // but this is a kill switch for a hung harness rather than a latency target: a run
+      // that finishes early costs nothing extra, so keep it above the slowest legitimate
+      // run rather than near it.
       per_model_timeout_seconds: 1800,
       // Zero means unlimited. The wall-clock timeout remains the hard safety boundary;
       // positive values are still accepted for users who want an explicit agent-step cap.

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -45,7 +45,7 @@ describe('defaultConfig', () => {
     expect(c.models.map((m) => m.id)).toEqual(['gpt-5.6-luna', 'deepseek-v4-flash-0731']);
     expect(c.models[0]?.harness).toBe('codex');
     expect(c.models[0]?.secret).toBe('JUROR_OPENAI_API_KEY');
-    expect(c.models[0]?.args?.['reasoning_effort']).toBe('max');
+    expect(c.models[0]?.args?.['reasoning_effort']).toBe('high');
     expect(c.models[1]?.harness).toBe('opencode');
     expect(c.models[1]?.secret).toBe('JUROR_FIREWORKS_API_KEY');
     expect(c.models[1]?.harness_model).toBe(
@@ -56,8 +56,9 @@ describe('defaultConfig', () => {
     expect(c.models[1]?.args?.['variant']).toBe('high');
     expect(c.consensus.verify_model).toBe('deepseek-v4-flash-0731');
     expect(c.consensus.referee_model).toBe('deepseek-v4-flash-0731');
-    // Luna at `max` was measured at 750–900s on large diffs. The wall must clear that with
-    // room to spare, or the default jury loses a model mid-review on big PRs.
+    // Kept well clear of the jury's slowest legitimate run: Luna was measured at 750–900s
+    // on large diffs at `max`, and is faster at `high`. This is a hung-harness kill switch,
+    // so headroom costs nothing and a tight wall silently drops a model mid-review.
     expect(c.review.per_model_timeout_seconds).toBe(1800);
   });
 
@@ -70,7 +71,7 @@ describe('defaultConfig', () => {
     const b = defaultConfig();
     expect(b.review.severity_floor).toBe('P3');
     expect(b.review.paths_ignore).not.toContain('mutated/**');
-    expect(b.models[0]?.args?.['reasoning_effort']).toBe('max');
+    expect(b.models[0]?.args?.['reasoning_effort']).toBe('high');
   });
 
   it('ships the requested fast, balanced, high, and ultra preset memberships', () => {
@@ -81,7 +82,7 @@ describe('defaultConfig', () => {
     const ultra = applyReviewPreset(base, 'ultra');
 
     expect(fast.models.map((m) => m.id)).toEqual(['gpt-5.6-luna', 'deepseek-v4-flash-0731']);
-    expect(fast.models.map((m) => m.args?.['reasoning_effort'] ?? m.args?.['variant'])).toEqual(['max', 'high']);
+    expect(fast.models.map((m) => m.args?.['reasoning_effort'] ?? m.args?.['variant'])).toEqual(['high', 'high']);
     expect(fast.consensus.referee_model).toBe('deepseek-v4-flash-0731');
     // No longer the default, so this is the only place its membership is pinned.
     expect(balanced.models.map((m) => m.id)).toEqual(['gpt-5.6-terra', 'grok-4.5', 'kimi-k3']);


### PR DESCRIPTION
Steps the default `fast` jury down one level: GPT-5.6 Luna `max` → `high`. DeepSeek stays at `high`, so both jurors now run the same tier.

| | before | after |
|---|---|---|
| GPT-5.6 Luna (Codex/OpenAI) | `max` | **`high`** |
| DeepSeek V4 Flash (opencode/Fireworks) | `high` | `high` |

## Why it matters more than it looks

`fast` is the default preset, and it is now running on `textcortex/platform` for every PR. At ~37 closed PRs per weekday and ~2 reviews per PR (the workflow fires on `synchronize`), the projected spend was ~$33/weekday, ~$740/month. This is the cheapest lever on that number that does not reduce coverage.

## Drive-by: a test that had gone vacuous

`hands out an independent copy each call` mutates `reasoning_effort` to `max` to prove `defaultConfig()` returns an independent object, then asserts a fresh copy still reads the default. When the default became `max` in v1.2.0 the mutation stopped differing from the default, so the assertion could no longer fail — a shared reference would have passed it.

Moving the default to `high` restores the contrast the test was written to check. Its comment already said *"Must differ from the default"*; now it does again.

## The timeout stays at 1800s

Deliberate. It is a kill switch for a hung harness, not a latency target — a jury that finishes well inside it costs nothing extra, and tightening it back down would re-introduce the v1.2.0 failure where a slow model is killed at the finish line and silently publishes nothing. Comments in `src/config.ts` and the test were updated so they no longer claim the jury runs at `max`.

## Verification

`npm run typecheck`, `npm run build`, `npm test` — 334 tests across 27 files, all passing. Confirmed against the built artifact rather than the source:

```
effective: gpt-5.6-luna high | deepseek-v4-flash-0731 high | timeout 1800
```

Version bumped to 1.3.1 in this PR. A follow-up will move `textcortex/platform`'s pinned SHA, which is intentionally immutable and will not pick this up on its own.