### PR TITLE
docs: point README benchmark at the real corpus file

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ is thrown away — that transparency is what makes the optional precision filter
 Replacement decisions can be evaluated with a manually adjudicated corpus:
 
 ```bash
-juror benchmark --file benchmarks/corpus.json
+npm run build && node dist/cli.js benchmark --file benchmarks/platform-10359.json
 ```
 
 The report compares P0–P2 recall, overall recall, precision, duplicate rate, measured cost,


### PR DESCRIPTION
## Summary
The README shadow-benchmark command referenced `benchmarks/corpus.json`, which is not in the repo. The only bundled corpus is `benchmarks/platform-10359.json` (also used in `docs/benchmarking.md`).

## Changes
- Point the README command at `benchmarks/platform-10359.json`
- Use `npm run build && node dist/cli.js …` so copy-paste works without a global `juror` install

Fixes #22