### PR TITLE
fix(log): validate JUROR_LOG_LEVEL and document it

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,6 +78,7 @@ Environment
   prefixed ones and give Juror its own provider key, so review spend is billed and
   tracked separately from everything else that account does.
   GITHUB_TOKEN
+  JUROR_LOG_LEVEL          debug | info | warn | error | silent (default: info)
   Any model whose key is absent is skipped with a note in the receipt — a repo with one
   key still gets a working review.
 `;

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -10,7 +10,19 @@ const red = (s: string) => (COLOR ? `\x1b[31m${s}\x1b[0m` : s);
 const yellow = (s: string) => (COLOR ? `\x1b[33m${s}\x1b[0m` : s);
 const cyan = (s: string) => (COLOR ? `\x1b[36m${s}\x1b[0m` : s);
 
-let current: LogLevel = (process.env.JUROR_LOG_LEVEL as LogLevel) || 'info';
+const LOG_LEVELS = Object.keys(ORDER) as LogLevel[];
+
+export function parseLogLevelEnv(raw: string | undefined): LogLevel {
+  if (!raw) return 'info';
+  if ((LOG_LEVELS as string[]).includes(raw)) return raw as LogLevel;
+  // Unrecognized values used to make ORDER[current] undefined so every line printed.
+  process.stderr.write(
+    `  ! JUROR_LOG_LEVEL=${JSON.stringify(raw)} is not one of ${LOG_LEVELS.join(', ')}; using info\n`,
+  );
+  return 'info';
+}
+
+let current: LogLevel = parseLogLevelEnv(process.env.JUROR_LOG_LEVEL);
 
 export function setLogLevel(level: LogLevel): void {
   current = level;

--- a/test/log-level.test.ts
+++ b/test/log-level.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getLogLevel, parseLogLevelEnv, setLogLevel } from '../src/util/log.js';
+
+describe('parseLogLevelEnv', () => {
+  afterEach(() => {
+    setLogLevel('info');
+  });
+
+  it('defaults to info when unset', () => {
+    expect(parseLogLevelEnv(undefined)).toBe('info');
+    expect(parseLogLevelEnv('')).toBe('info');
+  });
+
+  it('accepts known levels', () => {
+    for (const level of ['debug', 'info', 'warn', 'error', 'silent'] as const) {
+      expect(parseLogLevelEnv(level)).toBe(level);
+    }
+  });
+
+  it('falls back to info and warns once on unrecognized values', () => {
+    const write = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    expect(parseLogLevelEnv('verbose')).toBe('info');
+    expect(write).toHaveBeenCalled();
+    expect(String(write.mock.calls[0]?.[0])).toMatch(/JUROR_LOG_LEVEL/);
+    write.mockRestore();
+  });
+
+  it('setLogLevel updates getLogLevel', () => {
+    setLogLevel('error');
+    expect(getLogLevel()).toBe('error');
+  });
+});


### PR DESCRIPTION
## Summary
Typos like `JUROR_LOG_LEVEL=verbose` made every log line print (including debug) because `ORDER[current]` became `undefined`.

## Changes
- Validate against known levels; fall back to `info` and warn on stderr
- Document `JUROR_LOG_LEVEL` in CLI usage Environment
- Unit tests for parse/accept/fallback

Fixes #17