### PR TITLE
fix(review): use harness display labels on referee/verify cost rows

### DIFF
--- a/src/review.ts
+++ b/src/review.ts
@@ -29,6 +29,7 @@ import { refereeClusters } from './merge/referee.js';
 import { verifyClusters } from './merge/verify.js';
 import { applyPublishRules, requiredAgreement, scoreReview } from './merge/score.js';
 import { loadPricing, totalCost } from './cost/compute.js';
+import { getHarness } from './harness/registry.js';
 import { fanOut } from './harness/runner.js';
 import { synthesizeSummary } from './render/summary.js';
 import { loadPromptTemplate, readSecret, renderTemplate, resolveModelRuntime } from './config.js';
@@ -437,7 +438,7 @@ function findModel(config: JurorConfig, id: string | null): ModelConfig | null {
 }
 
 function harnessLabelOf(m: ModelConfig): string {
-  return m.harness;
+  return getHarness(m.harness).label;
 }
 
 function emptyResult(

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -652,6 +652,24 @@ describe('renderReceipt', () => {
     expect(md.trimEnd().endsWith('</details>')).toBe(true);
   });
 
+  it('shows harness display labels (not raw ids) on cost rows', () => {
+    // review.ts harnessLabelOf now uses getHarness(...).label so referee/verify
+    // rows match model rows (e.g. "Codex" not "codex").
+    const t = totals({
+      rows: [
+        {
+          label: 'referee (1 call)',
+          harnessLabel: 'Codex',
+          usage: null,
+          cost: { usd: 0.01, source: 'estimated', longContext: false },
+        },
+      ],
+    });
+    const md = renderReceipt(t, { durationMs: 1_000 });
+    expect(md).toContain('| `referee (1 call)` | Codex |');
+    expect(md).not.toMatch(/\| `referee \(1 call\)` \| codex \|/i);
+  });
+
   it('calls a partial total a lower bound and names the unknown rows', () => {
     const t = totals({
       rows: [


### PR DESCRIPTION
## Summary
Referee and verify cost rows used the raw harness id (`codex`) while model rows used the adapter display label (`Codex`).

## Changes
- `harnessLabelOf` → `getHarness(m.harness).label`
- Render test pins that receipt rows show the display label

Fixes #16