### PR TITLE
fix: keep pricing.json $meta.updated at least as fresh as its entries

### DIFF
--- a/src/cost/pricing.json
+++ b/src/cost/pricing.json
@@ -1,6 +1,6 @@
 {
   "$meta": {
-    "updated": "2026-08-06",
+    "updated": "2026-08-07",
     "note": "USD per million tokens (Mtok). Rates live under \"models\"; every top-level key starting with \"$\" is metadata and is ignored by loadPricing(), which also accepts a flat table so a hand-written override file need not know about the wrapper. Every entry carries the page it was read from and the date it was checked — a weekly CI job diffs this file against those pages and opens a PR on drift, because stale prices are the obvious failure mode for a tool whose pitch is cost honesty. Two things that are easy to get wrong and are deliberate here: (1) long_context is a cliff, not a slope — crossing threshold_input_tokens reprices the ENTIRE request, so a 199k-token Grok review costs half what a 201k one does; (2) cache writes are NOT free (OpenAI bills them at 1.25x uncached input for GPT-5.6 and later, Anthropic bills them too), so a missing cache_write_per_mtok means the provider publishes no separate write rate — grok-4.5 and the Fireworks models — and computeCost() falls back to that tier's input rate and says so in the receipt note. Omit a rate you do not know rather than inventing one: an absent entry makes computeCost() print \"unknown\", which is the only honest answer."
   },
   "models": {

--- a/test/cost.test.ts
+++ b/test/cost.test.ts
@@ -1,6 +1,7 @@
-import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 import { computeCost, loadPricing, totalCost } from '../src/cost/compute.js';
 import { loadRolling, recordSpend } from '../src/cost/rolling.js';
@@ -73,6 +74,25 @@ describe('pricing.json', () => {
       expect(entry.input_per_mtok, `${key} input`).toBeGreaterThan(0);
       expect(entry.output_per_mtok, `${key} output`).toBeGreaterThan(0);
     }
+  });
+
+  // loadPricing() strips $-prefixed keys, so this invariant has to read the raw file.
+  it("$meta.updated is never older than the newest model entry's updated date", () => {
+    const rawPath = join(dirname(fileURLToPath(import.meta.url)), '../src/cost/pricing.json');
+    const raw = JSON.parse(readFileSync(rawPath, 'utf8')) as {
+      $meta: { updated: string };
+      models: Record<string, { updated?: string }>;
+    };
+    expect(raw.$meta.updated).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    const entryDates = Object.entries(raw.models).map(([key, entry]) => {
+      expect(entry.updated, `${key} updated`).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      return entry.updated as string;
+    });
+    const newest = entryDates.reduce((a, b) => (a >= b ? a : b));
+    expect(
+      raw.$meta.updated >= newest,
+      `$meta.updated ${raw.$meta.updated} is older than newest entry ${newest}`,
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

`$meta.updated` was `2026-08-06` while the `gpt-5.6-luna` entry is dated `2026-08-07`. That stamp is the user-visible claim behind the `estimated` label and the pricing link on every receipt.

`loadPricing()` strips `$`-prefixed keys, so the existing per-entry test could not see the drift.

- Bump `$meta.updated` to `2026-08-07`
- Add a raw-JSON invariant that `$meta.updated` is never older than the newest model entry

## Test plan

- [x] `npm test -- test/cost.test.ts` (40 tests pass)

Fixes #21