### PR TITLE
fix: validate JUROR_LOG_LEVEL and document it in CLI usage

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,6 +78,8 @@ Environment
   prefixed ones and give Juror its own provider key, so review spend is billed and
   tracked separately from everything else that account does.
   GITHUB_TOKEN
+  JUROR_LOG_LEVEL          debug | info | warn | error | silent (default: info).
+                           Unrecognized values fall back to info with a one-time warning.
   Any model whose key is absent is skipped with a note in the receipt — a repo with one
   key still gets a working review.
 `;

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -10,7 +10,23 @@ const red = (s: string) => (COLOR ? `\x1b[31m${s}\x1b[0m` : s);
 const yellow = (s: string) => (COLOR ? `\x1b[33m${s}\x1b[0m` : s);
 const cyan = (s: string) => (COLOR ? `\x1b[36m${s}\x1b[0m` : s);
 
-let current: LogLevel = (process.env.JUROR_LOG_LEVEL as LogLevel) || 'info';
+let warnedInvalidLogLevel = false;
+
+/** Resolve an env/CLI log level; unknown values fall back to `info`. */
+export function resolveLogLevel(raw: string | undefined): LogLevel {
+  if (!raw) return 'info';
+  if (Object.prototype.hasOwnProperty.call(ORDER, raw)) return raw as LogLevel;
+  if (!warnedInvalidLogLevel) {
+    warnedInvalidLogLevel = true;
+    const allowed = Object.keys(ORDER).join(', ');
+    process.stderr.write(
+      yellow('  !') + ` JUROR_LOG_LEVEL="${raw}" is not recognized (expected one of: ${allowed}); using info\n`,
+    );
+  }
+  return 'info';
+}
+
+let current: LogLevel = resolveLogLevel(process.env.JUROR_LOG_LEVEL);
 
 export function setLogLevel(level: LogLevel): void {
   current = level;

--- a/test/log-level.test.ts
+++ b/test/log-level.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getLogLevel, resolveLogLevel, setLogLevel } from '../src/util/log.js';
+
+describe('resolveLogLevel', () => {
+  const levels = ['debug', 'info', 'warn', 'error', 'silent'] as const;
+
+  it('accepts every ORDER key', () => {
+    for (const level of levels) {
+      expect(resolveLogLevel(level)).toBe(level);
+    }
+  });
+
+  it('defaults to info when the value is missing or empty', () => {
+    expect(resolveLogLevel(undefined)).toBe('info');
+    expect(resolveLogLevel('')).toBe('info');
+  });
+
+  it('falls back to info for unrecognized values (e.g. a typo like verbose)', () => {
+    expect(resolveLogLevel('verbose')).toBe('info');
+    expect(resolveLogLevel('TRACE')).toBe('info');
+    expect(resolveLogLevel('Info')).toBe('info'); // case-sensitive
+  });
+
+  it('warns on stderr at most once for unrecognized values', () => {
+    const write = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    // Force at least one invalid resolution; the module may already have warned at import.
+    resolveLogLevel('not-a-level');
+    resolveLogLevel('also-bad');
+    const warnings = write.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes('JUROR_LOG_LEVEL') && s.includes('not recognized'));
+    // Across the whole process we should never emit more than one such line.
+    expect(warnings.length).toBeLessThanOrEqual(1);
+    write.mockRestore();
+  });
+});
+
+describe('setLogLevel / getLogLevel', () => {
+  afterEach(() => {
+    setLogLevel('info');
+  });
+
+  it('round-trips explicit CLI overrides', () => {
+    setLogLevel('debug');
+    expect(getLogLevel()).toBe('debug');
+    setLogLevel('error');
+    expect(getLogLevel()).toBe('error');
+  });
+});


### PR DESCRIPTION
## Summary

`JUROR_LOG_LEVEL` was cast straight to `LogLevel` with no check. A typo like `verbose` made `ORDER[current]` `undefined`, every level comparison false, and **every** log line (including `debug`) print — the opposite of what someone reaching for a log-level knob expects, and a CI log flood.

- Validate against the known `ORDER` keys; fall back to `info` and warn once on stderr for unrecognized values
- Document `JUROR_LOG_LEVEL` in the CLI `Environment` usage block
- Add unit coverage for accept / fallback / warn-once behavior

## Test plan

- [x] `npm test -- test/log-level.test.ts`
- [x] Spot-check: `JUROR_LOG_LEVEL=verbose` path falls back without flooding

Fixes #17