### PR TITLE
fix: show harness display labels on referee and verify receipt rows

### DIFF
--- a/src/review.ts
+++ b/src/review.ts
@@ -30,6 +30,7 @@ import { verifyClusters } from './merge/verify.js';
 import { applyPublishRules, requiredAgreement, scoreReview } from './merge/score.js';
 import { loadPricing, totalCost } from './cost/compute.js';
 import { fanOut } from './harness/runner.js';
+import { getHarness } from './harness/registry.js';
 import { synthesizeSummary } from './render/summary.js';
 import { loadPromptTemplate, readSecret, renderTemplate, resolveModelRuntime } from './config.js';
 import { loadAgentInstructions } from './instructions.js';
@@ -437,7 +438,7 @@ function findModel(config: JurorConfig, id: string | null): ModelConfig | null {
 }
 
 function harnessLabelOf(m: ModelConfig): string {
-  return m.harness;
+  return getHarness(m.harness).label;
 }
 
 function emptyResult(

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -693,6 +693,35 @@ describe('renderReceipt', () => {
     expect(md).toContain('Partial: `Kimi K3` (loop.max_steps_exceeded)');
     expect(md).not.toContain('Failed: `Kimi K3`');
   });
+
+  // Referee/verify rows use harnessLabelOf → getHarness(...).label. Receipt must show the
+  // display label (Codex), not the raw harness id (codex), so cost rows match model rows.
+  it('prints the harness display label on extra cost rows, not the raw id', () => {
+    const t = totals({
+      rows: [
+        ...totals().rows,
+        {
+          label: 'referee (1 call)',
+          harnessLabel: 'Codex',
+          usage: null,
+          cost: { usd: 0.0043, source: 'estimated', longContext: false },
+        },
+        {
+          label: 'verify (2 calls)',
+          harnessLabel: 'Kimi Code CLI',
+          usage: null,
+          cost: { usd: 0.01, source: 'estimated', longContext: false },
+        },
+      ],
+      usd: 0.1943,
+    });
+    const md = renderReceipt(t, { durationMs: 1_000 });
+    expect(md).toContain('| `referee (1 call)` | Codex |');
+    expect(md).toContain('| `verify (2 calls)` | Kimi Code CLI |');
+    // Raw harness ids must not appear in the harness column.
+    expect(md).not.toContain('| `referee (1 call)` | codex |');
+    expect(md).not.toContain('| kimi-code |');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`harnessLabelOf` returned the raw harness id for referee and verify cost rows, while every model row already used the adapter display label from `getHarness(...).label`. A Codex referee rendered as `codex` next to model rows reading `Codex`; Kimi as `kimi-code` next to `Kimi Code CLI`.

- One-line fix: `return getHarness(m.harness).label`
- Receipt test pins display labels on extra cost rows and rejects the raw ids

## Test plan

- [x] `npm test -- test/render.test.ts` (38 tests pass)
- [x] `tsc --noEmit` clean for the change

Fixes #16