### PR TITLE
docs: document the generic-openai harness in harness-notes.md

### DIFF
--- a/docs/harness-notes.md
+++ b/docs/harness-notes.md
@@ -235,8 +235,20 @@ POST {base_url}/chat/completions
   `generic-openai requires base_url in the model config` before any network call.
 - The request URL is always `{base_url}/chat/completions` with trailing slashes on
   `base_url` stripped. There is no alternate path, no Responses API, and no streaming.
-- The API key comes from `args.api_key_env` (or `args.secret`) naming an env var; absence
-  throws rather than silently falling through to an empty Bearer header.
+- **API key resolution is three tiers** (`resolveApiKey()`), first match wins:
+  1. **`ctx.providerKey`** — preferred. The runner-resolved provider secret wins before
+     any config is consulted.
+  2. **`args.api_key_env` / `args.secret`** — name of a child env var; that var's value is
+     used as the Bearer token.
+  3. **Single non-`SYSTEM_ENV` remainder** — if neither tier above yields a key and the
+     child env has *exactly one* non-system variable with a non-empty value, that value is
+     sent as the Bearer token to the configured `base_url`.
+  Absence does **not** throw at resolve time (a later error only fires when no key resolves
+  at all). **Tier 3 is a footgun / credential-disclosure risk:** `candidates.length === 1`
+  proves the value is unique in the child env, not that it is a credential. A config that
+  omits `api_key_env` and passes through one unrelated variable (a `SENTRY_DSN`, an internal
+  hostname, a webhook URL) will ship that value to a third-party endpoint in an
+  `Authorization` header.
 - **In-process only.** `command()` / `parse()` throw on purpose. `runner.ts` special-cases
   `h.id === 'generic-openai'` and calls `runGenericOpenAI(ctx)` instead of spawning.
   `locate()` reports `process.execPath` / `process.version` so the fan-out table still has
@@ -248,7 +260,13 @@ POST {base_url}/chat/completions
     scanned (`MAX_FILES_SCANNED`).
   - `list_dir` — at most **200** entries (`MAX_LIST_ENTRIES`).
   - `write_file` — only the configured findings path is writable; every other path is refused.
-- Paths outside the sealed repo root are refused. Relative paths resolve against `repoDir`.
+- **Path confinement is split.** Reads (`read_file` / `grep` / `list_dir`) go through
+  userland `confine()` — `realpathSync` + prefix check against `readRoots = [repoDir]` —
+  so paths outside the repo root are refused. `write_file` does **not** use `confine()`;
+  it is pinned by exact-path equality to `findingsPath` (often under `scratchDir`, outside
+  the repo root). Relative paths resolve against `repoDir`. This is userland path checking
+  only, not a kernel sandbox.
+
 - **Never reports a provider cost.** `reportedCostUsd` is always `null`. When the endpoint
   returns `usage`, token counts are accumulated (with `prompt_tokens` treated as including
   any cached prefix, so uncached = `prompt_tokens - cached_tokens`); cost is then

--- a/docs/harness-notes.md
+++ b/docs/harness-notes.md
@@ -232,7 +232,7 @@ POST {base_url}/chat/completions
 
 - **`base_url` is mandatory.** It is read from the model config's `base_url` field or
   `args.base_url`. Missing either throws
-  `generic-openai requires `base_url` in the model config` before any network call.
+  `generic-openai requires base_url in the model config` before any network call.
 - The request URL is always `{base_url}/chat/completions` with trailing slashes on
   `base_url` stripped. There is no alternate path, no Responses API, and no streaming.
 - The API key comes from `args.api_key_env` (or `args.secret`) naming an env var; absence

--- a/docs/harness-notes.md
+++ b/docs/harness-notes.md
@@ -9,8 +9,9 @@ disagrees with this file, re-measure before changing anything.**
 Measured 2026-08-06 against: `claude` 2.1.223 · `codex-cli` 0.146.1 · `grok` 0.2.118 ·
 `opencode` 1.17.20.
 
-Source-inspected (no paid provider run) against: `@moonshot-ai/kimi-code` 0.34.0. Its
-section below names that distinction rather than presenting inferred usage as measured.
+Source-inspected (no paid provider run) against: `@moonshot-ai/kimi-code` 0.34.0
+and the in-process `generic-openai` adapter in `src/harness/generic-openai.ts`. Their
+sections below name that distinction rather than presenting inferred usage as measured.
 
 `timeout(1)` does not exist on macOS, so every time limit is enforced in Node by
 `run()` in `src/util/proc.ts` rather than by the shell. On Unix the harness starts in its
@@ -214,6 +215,49 @@ omits `--max-turns` by default and adds it only for a positive custom `max_turns
 usage, returns `usage: null` so the receipt prints `unknown` rather than a fabricated number.
 
 ---
+
+
+## Generic OpenAI — in-process `/chat/completions` tool loop
+
+**Source-inspected** against `src/harness/generic-openai.ts` (no paid provider run). This is
+the escape-hatch adapter: any OpenAI-compatible chat endpoint can be driven without a native
+CLI harness. It has a lower ceiling than a real harness — no kernel sandbox, no
+provider-reported cost — which is why it is the fallback and not the default.
+
+```text
+POST {base_url}/chat/completions
+  Authorization: Bearer $API_KEY
+  body: { model, messages, tools: [read_file, grep, list_dir, write_file], tool_choice: "auto" }
+```
+
+- **`base_url` is mandatory.** It is read from the model config's `base_url` field or
+  `args.base_url`. Missing either throws
+  `generic-openai requires `base_url` in the model config` before any network call.
+- The request URL is always `{base_url}/chat/completions` with trailing slashes on
+  `base_url` stripped. There is no alternate path, no Responses API, and no streaming.
+- The API key comes from `args.api_key_env` (or `args.secret`) naming an env var; absence
+  throws rather than silently falling through to an empty Bearer header.
+- **In-process only.** `command()` / `parse()` throw on purpose. `runner.ts` special-cases
+  `h.id === 'generic-openai'` and calls `runGenericOpenAI(ctx)` instead of spawning.
+  `locate()` reports `process.execPath` / `process.version` so the fan-out table still has
+  a binary column.
+- Tools are Juror's own loop, not the provider's:
+  - `read_file` — hard-capped at **64 KiB** (`MAX_READ_BYTES`); longer files are truncated
+    with a note to request a line range.
+  - `grep` — at most **100** matches (`MAX_GREP_MATCHES`) across at most **2_000** files
+    scanned (`MAX_FILES_SCANNED`).
+  - `list_dir` — at most **200** entries (`MAX_LIST_ENTRIES`).
+  - `write_file` — only the configured findings path is writable; every other path is refused.
+- Paths outside the sealed repo root are refused. Relative paths resolve against `repoDir`.
+- **Never reports a provider cost.** `reportedCostUsd` is always `null`. When the endpoint
+  returns `usage`, token counts are accumulated (with `prompt_tokens` treated as including
+  any cached prefix, so uncached = `prompt_tokens - cached_tokens`); cost is then
+  `estimated` from `pricing.json`. No usage → `usage: null` and the receipt shows unknown.
+- Termination is wall-clock (`ctx.timeoutMs`) plus an optional positive `max_turns`. A
+  zero/negative turn cap means no turn limit. Abort signals and tool-pending turn limits
+  mark the run `truncated`.
+- Findings preference: the file written via `write_file` wins; a fenced JSON report in the
+  final assistant message is only a fallback when the file is missing.
 
 ## Consensus similarity — why it is not prose Jaccard
 


### PR DESCRIPTION
## Summary

`docs/harness-notes.md` is declared the ground truth adapters are written against, but it had sections for every shipped harness except `generic-openai` — even though that adapter is a first-class row in the README harness table.

Adds a **source-inspected** section (matching how the Kimi section is qualified) covering the load-bearing constraints from `src/harness/generic-openai.ts` / `runner.ts`:

- `base_url` is mandatory and throws without it
- Endpoint is always `{base_url}/chat/completions`
- Tool output caps (`MAX_READ_BYTES`, `MAX_GREP_MATCHES`, `MAX_LIST_ENTRIES`, …)
- Never reports a provider cost (`reportedCostUsd: null`)
- In-process only; `runner.ts` special-cases it instead of spawning

## Test plan

- [x] Docs-only change; reviewed against source for accuracy

Fixes #20