### PR TITLE
Fix README benchmark corpus path to platform-10359.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ is thrown away — that transparency is what makes the optional precision filter
 Replacement decisions can be evaluated with a manually adjudicated corpus:
 
 ```bash
-juror benchmark --file benchmarks/corpus.json
+npm run build && node dist/cli.js benchmark --file benchmarks/platform-10359.json
 ```
 
 The report compares P0–P2 recall, overall recall, precision, duplicate rate, measured cost,


### PR DESCRIPTION
## Summary

README invited `juror benchmark --file benchmarks/corpus.json`, but that file does not exist (only `benchmarks/platform-10359.json`). Aligned with `docs/benchmarking.md`.

## Test plan

- [x] Path matches file in repo
- [x] Command form matches docs (build + node dist/cli.js)

Fixes #22