### PR TITLE
docs: keep the benchmark example on the installed juror binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ is thrown away — that transparency is what makes the optional precision filter
 Replacement decisions can be evaluated with a manually adjudicated corpus:
 
 ```bash
-npm run build && node dist/cli.js benchmark --file benchmarks/platform-10359.json
+juror benchmark --file benchmarks/platform-10359.json
 ```
 
 The report compares P0–P2 recall, overall recall, precision, duplicate rate, measured cost,


### PR DESCRIPTION
Follow-up to #23, which fixed a real problem (the documented corpus path `benchmarks/corpus.json` does not exist — the file is `benchmarks/platform-10359.json`) but also switched the invocation to the from-source form.

This restores the bare `juror` form:

```diff
-npm run build && node dist/cli.js benchmark --file benchmarks/platform-10359.json
+juror benchmark --file benchmarks/platform-10359.json
```

Every other command in the README uses that form (lines 216-218, 278-279), as does the usage text `juror benchmark --file <corpus.json>` printed by `src/cli.ts:49`. The `npm run build && node dist/cli.js` form belongs to the from-source section at lines 470-473; using it here reads as if `benchmark` were not a shipped command, which it is (`package.json` maps `bin.juror` → `./dist/cli.js`).

This was meant to be pushed to #23 before merge, but that PR came from a fork and the commit landed on an upstream branch instead, so #23 merged without it. Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)