### PR TITLE
Fall back to a keyed jury member for referee/verify

### DIFF
--- a/src/review.ts
+++ b/src/review.ts
@@ -166,7 +166,7 @@ export async function runReview(o: ReviewOptions): Promise<ReviewResult> {
     log.step(`${initial.length} clusters · ${ambiguousPairs.length} ambiguous pairs`);
 
     // ── 6. Referee the ambiguous band ────────────────────────────────────────
-    const refereeModel = findModel(config, config.consensus.referee_model);
+    const refereeModel = findModel(config, config.consensus.referee_model, o.secrets, warnings);
     const refereed = await refereeClusters(ambiguousPairs, initial, {
       modelRun: refereeModel,
       pricing,
@@ -196,7 +196,9 @@ export async function runReview(o: ReviewOptions): Promise<ReviewResult> {
     // High-recall mode publishes every eligible deduplicated cluster, so a refutation pass
     // cannot affect the result. Skip it instead of charging for evidence we will not use.
     const consensusMode = config.review.publish_mode === 'consensus';
-    const verifyModel = consensusMode ? findModel(config, config.consensus.verify_model) : null;
+    const verifyModel = consensusMode
+      ? findModel(config, config.consensus.verify_model, o.secrets, warnings)
+      : null;
     const verificationThreshold = requiredAgreement(
       config.consensus.min_agreement,
       produced.length,
@@ -432,9 +434,40 @@ function restrictModels(config: JurorConfig, only: string[], warnings: string[])
   return { ...config, models };
 }
 
-function findModel(config: JurorConfig, id: string | null): ModelConfig | null {
+/**
+ * Resolve the model used for referee / verify.
+ *
+ * Prefer the configured id when it is enabled and has a readable secret.
+ * Otherwise fall back to the first enabled model whose secret can be read,
+ * and push a warning so the silent degradation is visible. Returns null when
+ * `id` is null (feature disabled) or no keyed enabled model exists.
+ */
+export function findModel(
+  config: JurorConfig,
+  id: string | null,
+  secrets: Record<string, string | undefined>,
+  warnings: string[],
+): ModelConfig | null {
   if (!id) return null;
-  return config.models.find((m) => m.id === id && m.enabled) ?? null;
+
+  const preferred = config.models.find((m) => m.id === id && m.enabled) ?? null;
+  if (preferred && hasSecret(readSecret(secrets, preferred.secret).value)) {
+    return preferred;
+  }
+
+  const fallback =
+    config.models.find((m) => m.enabled && hasSecret(readSecret(secrets, m.secret).value)) ?? null;
+  if (fallback) {
+    const reason = preferred
+      ? `has no readable secret (${preferred.secret})`
+      : 'is missing or disabled';
+    warnings.push(
+      `Configured model "${id}" ${reason}; falling back to "${fallback.id}" for referee/verify.`,
+    );
+    return fallback;
+  }
+
+  return null;
 }
 
 function harnessLabelOf(m: ModelConfig): string {

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import { defaultConfig } from '../src/config.js';
-import { reviewPromptVars, runReview } from '../src/review.js';
-import type { DiffContext } from '../src/types.js';
+import { findModel, reviewPromptVars, runReview } from '../src/review.js';
+import type { DiffContext, ModelConfig } from '../src/types.js';
 
 describe('runReview empty diff', () => {
   it('returns a complete serializable no-op result instead of requiring a model', async () => {
@@ -54,5 +54,80 @@ describe('review prompt context', () => {
 
     expect(vars['PR_CONTEXT']).toContain('Stage shared modules');
     expect(vars['PR_CONTEXT']).toContain('Copies are intentional');
+  });
+});
+
+describe('findModel secret-aware fallback', () => {
+  const openai: ModelConfig = {
+    id: 'gpt-5.6-luna',
+    harness: 'codex',
+    enabled: true,
+    secret: 'JUROR_OPENAI_API_KEY',
+    label: 'GPT-5.6 Luna',
+  };
+  const deepseek: ModelConfig = {
+    id: 'deepseek-v4-flash-0731',
+    harness: 'opencode',
+    enabled: true,
+    secret: 'JUROR_FIREWORKS_API_KEY',
+    label: 'DeepSeek V4 Flash',
+  };
+
+  it('prefers the configured id when its secret is readable', () => {
+    const config = {
+      ...defaultConfig(),
+      models: [openai, deepseek],
+      consensus: {
+        ...defaultConfig().consensus,
+        referee_model: 'deepseek-v4-flash-0731',
+      },
+    };
+    const warnings: string[] = [];
+    const model = findModel(
+      config,
+      'deepseek-v4-flash-0731',
+      { JUROR_FIREWORKS_API_KEY: 'fw-key', JUROR_OPENAI_API_KEY: 'oai-key' },
+      warnings,
+    );
+    expect(model?.id).toBe('deepseek-v4-flash-0731');
+    expect(warnings).toEqual([]);
+  });
+
+  it('falls back to the first enabled model with a readable secret and warns', () => {
+    // Default fast preset pins deepseek as consensus; common onboarding only has OpenAI.
+    const config = {
+      ...defaultConfig(),
+      models: [openai, deepseek],
+      consensus: {
+        ...defaultConfig().consensus,
+        referee_model: 'deepseek-v4-flash-0731',
+        verify_model: 'deepseek-v4-flash-0731',
+      },
+    };
+    const warnings: string[] = [];
+    const model = findModel(
+      config,
+      'deepseek-v4-flash-0731',
+      { JUROR_OPENAI_API_KEY: 'oai-key-only' },
+      warnings,
+    );
+    expect(model?.id).toBe('gpt-5.6-luna');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('deepseek-v4-flash-0731');
+    expect(warnings[0]).toContain('gpt-5.6-luna');
+    expect(warnings[0]).toMatch(/falling back/i);
+  });
+
+  it('returns null when id is null (referee/verify disabled)', () => {
+    const warnings: string[] = [];
+    expect(findModel(defaultConfig(), null, { JUROR_OPENAI_API_KEY: 'k' }, warnings)).toBeNull();
+    expect(warnings).toEqual([]);
+  });
+
+  it('returns null when no enabled model has a readable secret', () => {
+    const config = { ...defaultConfig(), models: [openai, deepseek] };
+    const warnings: string[] = [];
+    expect(findModel(config, 'deepseek-v4-flash-0731', {}, warnings)).toBeNull();
+    expect(warnings).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

### Fixes #15
`findModel` selected the referee/verify model by `id` + `enabled` only. With the default `fast` preset pinning `deepseek-v4-flash-0731` as the consensus model, a user who only set `JUROR_OPENAI_API_KEY` silently lost semantic deduplication and verification even though GPT-5.6 Luna was running.

**Change:** prefer the configured id when it is enabled **and** has a readable secret via `readSecret`; otherwise pick the first enabled model with a readable secret and **warn**. `id === null` still means the feature is disabled (no fallback).

## Design choices
- Secret check lives in `findModel` (call sites already have `o.secrets` and `warnings`) rather than deep in `refereeClusters` / `verifyClusters`, so both paths share one policy.
- If the configured model has no key and no other enabled model has a key either, return `null` (same effective skip as before) without a fallback warning noise.
- Exported `findModel` so unit tests can cover the policy without driving a full `runReview`.

## Test plan
- [x] `npm test` (361 passed, including new `findModel` cases in `test/review.test.ts`)
- [x] `tsc --noEmit`