### PR TITLE
fix(config): lower fast jury thinking

### DIFF
--- a/.juror.yml
+++ b/.juror.yml
@@ -10,7 +10,7 @@ version: 1
 # Built-in jury selection: fast | balanced | high | ultra. Missing provider keys simply
 # skip their models. `models:` can replace the selected preset with a fully custom jury.
 #
-# fast (default):     GPT-5.6 Luna high + DeepSeek V4 Flash high
+# fast (default):     GPT-5.6 Luna low + DeepSeek V4 Flash low
 # balanced:           GPT-5.6 Terra max + Grok 4.5 high + Kimi K3
 # high:               GPT-5.6 Sol + Opus 5 + Grok 4.5
 # ultra:              every model above, using the higher reasoning settings

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Juror ships four jury presets. Models whose provider key is unavailable are skip
 
 | Preset | Jury | Intended use |
 |---|---|---|
-| `fast` **(default)** | GPT-5.6 Luna via Codex/OpenAI (`high`) · DeepSeek V4 Flash via opencode/Fireworks (`high`) | Smallest, cheapest jury |
+| `fast` **(default)** | GPT-5.6 Luna via Codex/OpenAI (`low`) · DeepSeek V4 Flash via opencode/Fireworks (`low`) | Smallest, cheapest jury |
 | `balanced` | GPT-5.6 Terra via Codex/OpenAI (`max`) · Grok 4.5 via Grok Build/xAI (`high`) · Kimi K3 via Kimi Code/Fireworks (`max`) | Strong provider diversity without the full burn |
 | `high` | GPT-5.6 Sol via Codex/OpenAI (`high`) · Opus 5 via Claude Code/Anthropic · Grok 4.5 via Grok Build/xAI (`high`) | Higher-confidence frontier jury |
 | `ultra` | Every model from the other presets (seven total), using their higher reasoning settings | Maximum coverage; highest token and cost use |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juror-ai",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juror-ai",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juror-ai",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Multi-model PR review that shows you the bill. Duplicate findings collapse into one, with optional agreement filtering.",
   "license": "MIT",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,7 @@ import { checkoutAt, type EphemeralCheckout } from './util/worktree.js';
 import { evaluateBenchmark, parseBenchmarkCorpus, renderBenchmark } from './benchmark.js';
 import { loadAgentInstructions } from './instructions.js';
 
-export const VERSION = '1.3.1';
+export const VERSION = '1.3.2';
 
 const USAGE = `
 juror ${VERSION} — multi-model PR review that shows you the bill

--- a/src/config.ts
+++ b/src/config.ts
@@ -181,8 +181,8 @@ const PRESET_DEFINITIONS: Record<ReviewPreset, PresetDefinition> = {
     modelIds: ['gpt-5.6-luna', 'deepseek-v4-flash-0731'],
     consensusModel: 'deepseek-v4-flash-0731',
     args: {
-      'gpt-5.6-luna': { reasoning_effort: 'high' },
-      'deepseek-v4-flash-0731': { variant: 'high' },
+      'gpt-5.6-luna': { reasoning_effort: 'low' },
+      'deepseek-v4-flash-0731': { variant: 'low' },
     },
   },
   balanced: {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -45,19 +45,19 @@ describe('defaultConfig', () => {
     expect(c.models.map((m) => m.id)).toEqual(['gpt-5.6-luna', 'deepseek-v4-flash-0731']);
     expect(c.models[0]?.harness).toBe('codex');
     expect(c.models[0]?.secret).toBe('JUROR_OPENAI_API_KEY');
-    expect(c.models[0]?.args?.['reasoning_effort']).toBe('high');
+    expect(c.models[0]?.args?.['reasoning_effort']).toBe('low');
     expect(c.models[1]?.harness).toBe('opencode');
     expect(c.models[1]?.secret).toBe('JUROR_FIREWORKS_API_KEY');
     expect(c.models[1]?.harness_model).toBe(
       'fireworks-ai/accounts/fireworks/models/deepseek-v4-flash-0731',
     );
     expect(c.models[1]?.pricing_key).toBe('accounts/fireworks/models/deepseek-v4-flash-0731');
-    // The preset pins `high` explicitly rather than inheriting the model's built-in default.
-    expect(c.models[1]?.args?.['variant']).toBe('high');
+    // The fast preset deliberately lowers both models' thinking settings.
+    expect(c.models[1]?.args?.['variant']).toBe('low');
     expect(c.consensus.verify_model).toBe('deepseek-v4-flash-0731');
     expect(c.consensus.referee_model).toBe('deepseek-v4-flash-0731');
     // Kept well clear of the jury's slowest legitimate run: Luna was measured at 750–900s
-    // on large diffs at `max`, and is faster at `high`. This is a hung-harness kill switch,
+    // on large diffs at `max`, and is faster at `low`. This is a hung-harness kill switch,
     // so headroom costs nothing and a tight wall silently drops a model mid-review.
     expect(c.review.per_model_timeout_seconds).toBe(1800);
   });
@@ -71,7 +71,7 @@ describe('defaultConfig', () => {
     const b = defaultConfig();
     expect(b.review.severity_floor).toBe('P3');
     expect(b.review.paths_ignore).not.toContain('mutated/**');
-    expect(b.models[0]?.args?.['reasoning_effort']).toBe('high');
+    expect(b.models[0]?.args?.['reasoning_effort']).toBe('low');
   });
 
   it('ships the requested fast, balanced, high, and ultra preset memberships', () => {
@@ -82,7 +82,7 @@ describe('defaultConfig', () => {
     const ultra = applyReviewPreset(base, 'ultra');
 
     expect(fast.models.map((m) => m.id)).toEqual(['gpt-5.6-luna', 'deepseek-v4-flash-0731']);
-    expect(fast.models.map((m) => m.args?.['reasoning_effort'] ?? m.args?.['variant'])).toEqual(['high', 'high']);
+    expect(fast.models.map((m) => m.args?.['reasoning_effort'] ?? m.args?.['variant'])).toEqual(['low', 'low']);
     expect(fast.consensus.referee_model).toBe('deepseek-v4-flash-0731');
     // No longer the default, so this is the only place its membership is pinned.
     expect(balanced.models.map((m) => m.id)).toEqual(['gpt-5.6-terra', 'grok-4.5', 'kimi-k3']);


### PR DESCRIPTION
## TL;DR
Lowers both models in the default fast jury to low thinking and prepares patch release 1.3.2. This reduces the default review latency and cost for both GitHub Action and npm users.

## Summary
- set GPT-5.6 Luna reasoning effort to low in the fast preset
- set DeepSeek V4 Flash variant to low in the fast preset
- update tests and user-facing configuration docs
- bump package and CLI version to 1.3.2

## Review focus
- confirm the fast preset passes the correct provider-specific low settings
- no database migrations or breaking changes

## Test plan
- [x] npm run typecheck
- [x] npm run build
- [x] npm test (357 tests)
- [x] npm pack --dry-run