### PR TITLE
feat(config): add one-secret multi-model starter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ JUROR_ANTHROPIC_API_KEY=
 JUROR_OPENAI_API_KEY=
 JUROR_XAI_API_KEY=
 JUROR_FIREWORKS_API_KEY=
+JUROR_OPENROUTER_API_KEY=
 
 # The unprefixed vendor names still work as a fallback, so an existing setup keeps
 # running unchanged. A prefixed key always wins when both are set.
@@ -14,3 +15,4 @@ JUROR_FIREWORKS_API_KEY=
 # OPENAI_API_KEY=
 # XAI_API_KEY=
 # FIREWORKS_API_KEY=
+# OPENROUTER_API_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - run: npm test
       - run: npm run check:secure-refs
 
-  # This repo is public and is handed four provider keys at runtime. One committed key is
+  # This repo is public and is handed provider keys at runtime. One committed key is
   # the worst thing that can happen to it, so the check is a build gate rather than a habit.
   secrets-scan:
     runs-on: ubuntu-latest
@@ -37,6 +37,7 @@ jobs:
           # cries wolf on its own definitions gets muted within a week.
           PATTERN='sk-ant-api[0-9]{2}-[A-Za-z0-9_-]{40,}'
           PATTERN="$PATTERN|sk-proj-[A-Za-z0-9_-]{40,}"
+          PATTERN="$PATTERN|sk-or-v1-[A-Za-z0-9_-]{40,}"
           PATTERN="$PATTERN|xai-[A-Za-z0-9]{40,}"
           PATTERN="$PATTERN|fw_[A-Za-z0-9]{20,}"
           PATTERN="$PATTERN|gh[pousr]_[A-Za-z0-9]{36}"

--- a/.github/workflows/juror.yml
+++ b/.github/workflows/juror.yml
@@ -32,3 +32,4 @@ jobs:
           JUROR_OPENAI_API_KEY: ${{ secrets.JUROR_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
           JUROR_XAI_API_KEY: ${{ secrets.JUROR_XAI_API_KEY || secrets.XAI_API_KEY }}
           JUROR_FIREWORKS_API_KEY: ${{ secrets.JUROR_FIREWORKS_API_KEY || secrets.FIREWORKS_API_KEY }}
+          JUROR_OPENROUTER_API_KEY: ${{ secrets.JUROR_OPENROUTER_API_KEY || secrets.OPENROUTER_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ Any key used by the selected preset gets you a working review. Missing providers
 with a note in the receipt. The default `fast` preset becomes a cross-model jury when both
 OpenAI and Fireworks are available. Degrade, never pretend.
 
+Want to evaluate the two-family jury with one credential? The opt-in `starter` preset routes
+fixed OpenAI and DeepSeek model revisions through OpenRouter's OpenAI-compatible API:
+
+```bash
+export JUROR_OPENROUTER_API_KEY=…
+npx juror-ai init --preset starter --set-secrets
+```
+
+`starter` is intentionally not the default yet. It must meet the existing `fast` preset on the
+adjudicated seed and expanded corpus before the onboarding recommendation changes. Direct
+first-party OpenAI, Fireworks, Anthropic, and xAI credentials remain the higher-control path:
+they avoid an aggregator trust boundary and use each vendor's native agent harness.
+
 Open a pull request. Juror posts a sticky *Juror is reviewing…* comment right away,
 then replaces it in place with the findings, the merge score, and the bill.
 
@@ -237,14 +250,17 @@ JUROR_ANTHROPIC_API_KEY=…
 JUROR_OPENAI_API_KEY=…
 JUROR_FIREWORKS_API_KEY=…
 JUROR_XAI_API_KEY=…
+JUROR_OPENROUTER_API_KEY=…
 ```
 
 ---
 
 ## Supported models & harnesses
 
-Juror drives each model through its **native agent harness**, so each one greps your repo
-the way its vendor intended.
+Juror normally drives each model through its **native agent harness**, so each one greps your
+repo the way its vendor intended. The opt-in one-secret starter uses Juror's confined in-process
+tool loop against OpenRouter instead; it preserves the same sealed checkout and exact findings
+file boundary without installing another executable.
 
 | Harness | CLI | Models | Reports cost | Sandbox |
 |---|---|---|---|---|
@@ -253,7 +269,7 @@ the way its vendor intended.
 | `opencode` | `opencode run` | anything on [models.dev](https://models.dev) — Fireworks, Groq, OpenRouter, … | ✅ per-step `cost` | tool removal |
 | `grok-build` | `grok -p` | Grok models | ✅ `total_cost_usd` | Landlock |
 | `kimi-code` | `kimi -p` | Kimi K3 on Fireworks | ❌ → estimated from session usage | tool allowlist + isolated runtime |
-| `generic-openai` | *(in-process)* | any OpenAI-compatible endpoint | ❌ → estimated | path-confined tools |
+| `generic-openai` | *(in-process)* | any OpenAI-compatible endpoint | provider-reported when documented; otherwise estimated | path-confined tools |
 
 The `opencode` harness is the reason adding a model is a config edit rather than a PR. To add
 **DeepSeek V4 Flash** to your jury:
@@ -272,11 +288,12 @@ models:
 
 ## Configuration
 
-Juror ships four jury presets. Models whose provider key is unavailable are skipped, so
+Juror ships five jury presets. Models whose provider key is unavailable are skipped, so
 `ultra` means every built-in model that can actually authenticate on that runner.
 
 | Preset | Jury | Intended use |
 |---|---|---|
+| `starter` *(opt-in)* | GPT-5.6 Luna · DeepSeek V4 Flash through OpenRouter's confined generic harness | Two model families from one `JUROR_OPENROUTER_API_KEY`; awaiting benchmark promotion gate |
 | `fast` **(default)** | GPT-5.6 Luna via Codex/OpenAI (`low`) · DeepSeek V4 Flash via opencode/Fireworks (`low`) | Smallest, cheapest jury |
 | `balanced` | GPT-5.6 Terra via Codex/OpenAI (`max`) · Grok 4.5 via Grok Build/xAI (`high`) · Kimi K3 via Kimi Code/Fireworks (`max`) | Strong provider diversity without the full burn |
 | `high` | GPT-5.6 Sol via Codex/OpenAI (`high`) · Opus 5 via Claude Code/Anthropic · Grok 4.5 via Grok Build/xAI (`high`) | Higher-confidence frontier jury |
@@ -286,6 +303,7 @@ Select one in config, on the CLI, or in the Action:
 
 ```bash
 juror review --preset fast --base main
+juror review --preset starter --base main
 juror review --mode ultra --pr 1234 --repo owner/name
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: Path to the Juror config file. Defaults to .juror.yml at the repo root.
     required: false
   preset:
-    description: Jury preset (fast, balanced, high, or ultra). Defaults to fast unless config overrides it.
+    description: Jury preset (starter, fast, balanced, high, or ultra). Defaults to fast unless config overrides it.
     required: false
   models:
     description: Comma-separated model ids to run, overriding the config's enabled set.
@@ -67,10 +67,12 @@ runs:
         JUROR_OPENAI_API_KEY: ''
         JUROR_FIREWORKS_API_KEY: ''
         JUROR_XAI_API_KEY: ''
+        JUROR_OPENROUTER_API_KEY: ''
         ANTHROPIC_API_KEY: ''
         OPENAI_API_KEY: ''
         FIREWORKS_API_KEY: ''
         XAI_API_KEY: ''
+        OPENROUTER_API_KEY: ''
         GITHUB_TOKEN: ''
         GH_TOKEN: ''
       with:
@@ -87,10 +89,12 @@ runs:
         JUROR_OPENAI_API_KEY: ''
         JUROR_FIREWORKS_API_KEY: ''
         JUROR_XAI_API_KEY: ''
+        JUROR_OPENROUTER_API_KEY: ''
         ANTHROPIC_API_KEY: ''
         OPENAI_API_KEY: ''
         FIREWORKS_API_KEY: ''
         XAI_API_KEY: ''
+        OPENROUTER_API_KEY: ''
         GITHUB_TOKEN: ''
         GH_TOKEN: ''
         ACTION_PATH: ${{ github.action_path }}
@@ -114,10 +118,12 @@ runs:
         JUROR_OPENAI_API_KEY: ''
         JUROR_FIREWORKS_API_KEY: ''
         JUROR_XAI_API_KEY: ''
+        JUROR_OPENROUTER_API_KEY: ''
         ANTHROPIC_API_KEY: ''
         OPENAI_API_KEY: ''
         FIREWORKS_API_KEY: ''
         XAI_API_KEY: ''
+        OPENROUTER_API_KEY: ''
         GITHUB_TOKEN: ''
         GH_TOKEN: ''
       with:
@@ -135,10 +141,12 @@ runs:
         JUROR_OPENAI_API_KEY: ''
         JUROR_FIREWORKS_API_KEY: ''
         JUROR_XAI_API_KEY: ''
+        JUROR_OPENROUTER_API_KEY: ''
         ANTHROPIC_API_KEY: ''
         OPENAI_API_KEY: ''
         FIREWORKS_API_KEY: ''
         XAI_API_KEY: ''
+        OPENROUTER_API_KEY: ''
         GITHUB_TOKEN: ''
         GH_TOKEN: ''
       run: |
@@ -155,6 +163,8 @@ runs:
         CODEX_SPEC: ${{ inputs.codex-version }}
         OPENCODE_SPEC: ${{ inputs.opencode-version }}
         KIMI_CODE_SPEC: ${{ inputs.kimi-code-version }}
+        JUROR_OPENROUTER_API_KEY: ''
+        OPENROUTER_API_KEY: ''
       run: |
         set -euo pipefail
         HAS_ANTHROPIC="${JUROR_ANTHROPIC_API_KEY:-${ANTHROPIC_API_KEY:-}}"
@@ -182,10 +192,12 @@ runs:
         JUROR_OPENAI_API_KEY: ''
         JUROR_FIREWORKS_API_KEY: ''
         JUROR_XAI_API_KEY: ''
+        JUROR_OPENROUTER_API_KEY: ''
         ANTHROPIC_API_KEY: ''
         OPENAI_API_KEY: ''
         FIREWORKS_API_KEY: ''
         XAI_API_KEY: ''
+        OPENROUTER_API_KEY: ''
         GITHUB_TOKEN: ''
         GH_TOKEN: ''
       with:
@@ -202,6 +214,8 @@ runs:
         OPENCODE_SPEC: ${{ inputs.opencode-version }}
         KIMI_CODE_SPEC: ${{ inputs.kimi-code-version }}
         HARNESS_ROOT: ${{ runner.temp }}/juror-harnesses
+        JUROR_OPENROUTER_API_KEY: ''
+        OPENROUTER_API_KEY: ''
       run: |
         set -euo pipefail
         # A prefixed key wins, the bare vendor name is the pre-1.3 fallback. Gating on the
@@ -210,7 +224,7 @@ runs:
         HAS_OPENAI="${JUROR_OPENAI_API_KEY:-${OPENAI_API_KEY:-}}"
         HAS_FIREWORKS="${JUROR_FIREWORKS_API_KEY:-${FIREWORKS_API_KEY:-}}"
         HAS_XAI="${JUROR_XAI_API_KEY:-${XAI_API_KEY:-}}"
-        CLEAN_ENV=(env -u JUROR_ANTHROPIC_API_KEY -u JUROR_OPENAI_API_KEY -u JUROR_FIREWORKS_API_KEY -u JUROR_XAI_API_KEY -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u FIREWORKS_API_KEY -u XAI_API_KEY -u GITHUB_TOKEN -u GH_TOKEN)
+        CLEAN_ENV=(env -u JUROR_ANTHROPIC_API_KEY -u JUROR_OPENAI_API_KEY -u JUROR_FIREWORKS_API_KEY -u JUROR_XAI_API_KEY -u JUROR_OPENROUTER_API_KEY -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u FIREWORKS_API_KEY -u XAI_API_KEY -u OPENROUTER_API_KEY -u GITHUB_TOKEN -u GH_TOKEN)
         mkdir -p "$HARNESS_ROOT"
         install_harness() {
           local binary="$1" spec="$2"

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -37,3 +37,20 @@ across the full corpus, not just in aggregate on one favorable PR.
 `benchmarks/platform-10359.json` is a seed based on the reviewed PR and the two supplied
 Greptile comments. It is intentionally one case and must not be presented as statistically
 sufficient evidence that either reviewer can replace the other.
+
+## Starter-preset promotion gate
+
+The one-secret `starter` preset is opt-in until it is compared with `fast` on the same commit
+and adjudicated expectations. Run both reviews with dedicated credentials and preserve their
+JSON reports before adding the mapped findings to the corpus:
+
+```bash
+juror review --preset fast --pr <number> --repo <owner/name> --json fast.json
+juror review --preset starter --pr <number> --repo <owner/name> --json starter.json
+```
+
+The comparison must record failed/skipped jurors, provider-reported cost, wall time, recall,
+precision, and duplicate rate. Do not promote `starter` merely because it is easier to
+configure: it should meet or exceed `fast` on adjudicated P0–P2 recall without an unacceptable
+precision or cost regression. A missing OpenRouter credential is a blocked benchmark, not a
+zero-cost or passing run.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -27,7 +27,7 @@ advisory and must not be treated as authorization to merge, deploy, or execute c
 | Boundary | Threat | Primary controls | Residual risk |
 |---|---|---|---|
 | Untrusted pull request text and repository files | Prompt injection, malicious hooks, oversized input, misleading policy | Review from a detached checkout; load policy and execution config from the base revision; do not use `pull_request_target`; treat PR metadata as untrusted | A model can still produce a wrong or attacker-influenced review |
-| Provider keys | Exfiltration through tools, logs, child processes, or committed configuration | One provider credential per harness; rebuilt child environments; secret redaction; `juror init` sends secrets to GitHub over stdin; untracked `.env` files stay outside reviewer roots | A compromised provider CLI can use its own credential while it is running |
+| Provider keys | Exfiltration through tools, logs, child processes, or committed configuration | One provider credential per harness invocation; rebuilt child environments; secret redaction; `juror init` sends secrets to GitHub over stdin; untracked `.env` files stay outside reviewer roots | A compromised provider CLI can use its own credential while it is running; an aggregator key authorizes every selected model routed through that aggregator |
 | GitHub token | Repository mutation or disclosure to a model | Never pass it to model subprocesses; publish only after jurors exit; request `contents: read` and `pull-requests: write`; fork reviews receive no secrets | The trusted publishing process can create or edit review comments by design |
 | Model subprocesses | Shell execution, filesystem escape, persistence, cross-juror leakage | Private temporary homes, read-only/search-only tools where supported, kernel filesystem restrictions for Codex, path confinement for the generic harness, separate scratch directories | Sandboxing differs by harness and operating system; a harness vulnerability may weaken it |
 | Harness packages and installer scripts | Compromised npm package, mutable installer response, postinstall code, or binary substitution | Exact package versions in Action inputs; credential-stripped installation environment; isolated runner; immutable Action revision; cache keys include harness specs | The Grok installer script is fetched from the vendor at runtime and is not content-addressed; disable xAI or preinstall an audited binary when this is unacceptable |
@@ -61,6 +61,14 @@ artifact is exposed by the integration. Piping a network response to a shell tru
 TLS path, and current response. Security-sensitive operators should omit the xAI key/model or
 use a controlled runner with a preinstalled, audited CLI. Installer failure degrades that juror
 explicitly; it must never be represented as model agreement.
+
+The `starter` preset uses one OpenRouter key for two isolated `generic-openai` runs. That key is
+used only as an HTTP authorization header inside Juror; it is never inserted into the prompt,
+tool messages, report, or scratch files. Each model still receives a separate scratch directory
+and the same path-confined read/write tools. This removes extra CLI installers but adds
+OpenRouter as a routing, billing, and data-processing trust boundary. Use direct first-party
+presets when provider selection, retention terms, or independent credentials matter more than
+one-secret onboarding.
 
 ## GitHub workflow trust
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,7 +59,7 @@ Options
   --repo-dir <path>      Repository checkout to read (default: cwd)
   --head <ref>           Head ref for local mode (default: HEAD)
   --config <path>        Config file (default: .juror.yml in the repo)
-  --preset <name>        Jury preset: fast (default), balanced, high, or ultra
+  --preset <name>        Jury preset: starter (one OpenRouter key), fast (default), balanced, high, or ultra
   --mode <name>          Alias for --preset
   --models <a,b,c>       Only run these model ids
   --post                 Post the review to the pull request (requires --pr and GITHUB_TOKEN)
@@ -81,6 +81,7 @@ Init
 
 Environment
   JUROR_ANTHROPIC_API_KEY  JUROR_OPENAI_API_KEY  JUROR_XAI_API_KEY  JUROR_FIREWORKS_API_KEY
+  JUROR_OPENROUTER_API_KEY
   The unprefixed names (ANTHROPIC_API_KEY, …) still work as a fallback. Prefer the
   prefixed ones and give Juror its own provider key, so review spend is billed and
   tracked separately from everything else that account does.
@@ -249,6 +250,7 @@ async function main(): Promise<number> {
       env: process.env as Record<string, string | undefined>,
       version: VERSION,
       actionSha: args.actionSha,
+      preset: args.preset,
       dryRun: args.dryRun,
       setSecrets: args.setSecrets,
       yes: args.yes,

--- a/src/config.ts
+++ b/src/config.ts
@@ -105,9 +105,31 @@ const SUPPRESSED_MODES = ['collapsed', 'hidden', 'inline'] as const;
 const ON_EXCEED_MODES = ['partial', 'skip'] as const;
 const PUBLISH_MODES = ['all', 'consensus'] as const;
 
-export const REVIEW_PRESETS = ['fast', 'balanced', 'high', 'ultra'] as const satisfies readonly ReviewPreset[];
+export const REVIEW_PRESETS = ['starter', 'fast', 'balanced', 'high', 'ultra'] as const satisfies readonly ReviewPreset[];
 
 const BUILTIN_MODELS: Record<string, ModelConfig> = {
+  'openrouter-gpt-5.6-luna': {
+    id: 'openrouter-gpt-5.6-luna',
+    harness: 'generic-openai',
+    enabled: true,
+    secret: 'JUROR_OPENROUTER_API_KEY',
+    label: 'GPT-5.6 Luna',
+    base_url: 'https://openrouter.ai/api/v1',
+    harness_model: 'openai/gpt-5.6-luna',
+    pricing_key: 'openrouter/openai/gpt-5.6-luna-20260709',
+    args: { usage_cost: 'usd' },
+  },
+  'openrouter-deepseek-v4-flash': {
+    id: 'openrouter-deepseek-v4-flash',
+    harness: 'generic-openai',
+    enabled: true,
+    secret: 'JUROR_OPENROUTER_API_KEY',
+    label: 'DeepSeek V4 Flash',
+    base_url: 'https://openrouter.ai/api/v1',
+    harness_model: 'deepseek/deepseek-v4-flash-0731',
+    pricing_key: 'openrouter/deepseek/deepseek-v4-flash-20260731',
+    args: { usage_cost: 'usd' },
+  },
   'claude-opus-5': {
     id: 'claude-opus-5',
     harness: 'claude-code',
@@ -177,6 +199,10 @@ interface PresetDefinition {
 }
 
 const PRESET_DEFINITIONS: Record<ReviewPreset, PresetDefinition> = {
+  starter: {
+    modelIds: ['openrouter-gpt-5.6-luna', 'openrouter-deepseek-v4-flash'],
+    consensusModel: 'openrouter-deepseek-v4-flash',
+  },
   fast: {
     modelIds: ['gpt-5.6-luna', 'deepseek-v4-flash-0731'],
     consensusModel: 'deepseek-v4-flash-0731',

--- a/src/cost/compute.ts
+++ b/src/cost/compute.ts
@@ -266,8 +266,10 @@ export function totalCost(
 ): CostTotals {
   const rows: CostRow[] = runs.map((run) => ({
     label: run.modelLabel,
+    ...(run.result?.resolvedModel ? { modelRef: run.result.resolvedModel } : {}),
     harnessLabel: run.harnessLabel,
     usage: run.result?.usage ?? null,
+    ...(run.result?.usageSource ? { usageSource: run.result.usageSource } : {}),
     cost: rowCost(run),
   }));
   for (const e of extra) {

--- a/src/cost/pricing.json
+++ b/src/cost/pricing.json
@@ -1,9 +1,35 @@
 {
   "$meta": {
-    "updated": "2026-08-07",
+    "updated": "2026-08-11",
     "note": "USD per million tokens (Mtok). Rates live under \"models\"; every top-level key starting with \"$\" is metadata and is ignored by loadPricing(), which also accepts a flat table so a hand-written override file need not know about the wrapper. Every entry carries the page it was read from and the date it was checked — a weekly CI job diffs this file against those pages and opens a PR on drift, because stale prices are the obvious failure mode for a tool whose pitch is cost honesty. Two things that are easy to get wrong and are deliberate here: (1) long_context is a cliff, not a slope — crossing threshold_input_tokens reprices the ENTIRE request, so a 199k-token Grok review costs half what a 201k one does; (2) cache writes are NOT free (OpenAI bills them at 1.25x uncached input for GPT-5.6 and later, Anthropic bills them too), so a missing cache_write_per_mtok means the provider publishes no separate write rate — grok-4.5 and the Fireworks models — and computeCost() falls back to that tier's input rate and says so in the receipt note. Omit a rate you do not know rather than inventing one: an absent entry makes computeCost() print \"unknown\", which is the only honest answer."
   },
   "models": {
+    "openrouter/openai/gpt-5.6-luna-20260709": {
+      "input_per_mtok": 0.1,
+      "output_per_mtok": 0.6,
+      "cache_read_per_mtok": 0.01,
+      "cache_write_per_mtok": 0.125,
+      "cache_min_prefix_tokens": 1024,
+      "context_window": 1050000,
+      "long_context": {
+        "threshold_input_tokens": 272000,
+        "applies_to": "entire_request",
+        "input_per_mtok": 0.2,
+        "output_per_mtok": 0.9,
+        "cache_read_per_mtok": 0.02,
+        "cache_write_per_mtok": 0.25
+      },
+      "source": "https://openrouter.ai/api/v1/models",
+      "updated": "2026-08-11"
+    },
+    "openrouter/deepseek/deepseek-v4-flash-20260731": {
+      "input_per_mtok": 0.08,
+      "output_per_mtok": 0.18,
+      "cache_read_per_mtok": 0.016,
+      "context_window": 1048576,
+      "source": "https://openrouter.ai/api/v1/models",
+      "updated": "2026-08-11"
+    },
     "claude-opus-5": {
       "input_per_mtok": 5.0,
       "output_per_mtok": 25.0,

--- a/src/harness/generic-openai.ts
+++ b/src/harness/generic-openai.ts
@@ -5,8 +5,8 @@
  * today ships a breaking flag next month. This adapter drives any OpenAI-compatible
  * `/chat/completions` endpoint through our own small read/grep/list/write tool loop, so
  * adding a model is a config edit rather than a pull request. It has a lower ceiling than
- * a real harness — no kernel sandbox, no provider-reported cost — which is exactly why it
- * is the fallback and not the default.
+ * a real harness — no kernel sandbox, and cost is provider-reported only when the endpoint
+ * explicitly documents USD usage — which is exactly why it is the fallback and not the default.
  *
  * It is also the only adapter that does not spawn a process, so `runner.ts` special-cases
  * `id === 'generic-openai'` and calls `runGenericOpenAI()` instead of command/parse.
@@ -162,6 +162,10 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 
 function num(v: unknown): number {
   return typeof v === 'number' && Number.isFinite(v) ? v : 0;
+}
+
+function nonNegativeNumber(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? v : null;
 }
 
 function readString(v: unknown): string | null {
@@ -492,6 +496,10 @@ export async function runGenericOpenAI(ctx: RunContext, signal?: AbortSignal): P
   const diagnostics: string[] = [];
   const deadline = Date.now() + ctx.timeoutMs;
   let sawUsage = false;
+  let reportedCostUsd = 0;
+  let usageTurns = 0;
+  let costedTurns = 0;
+  const resolvedModels = new Set<string>();
   let truncated = false;
   let rawText = '';
   let turns = 0;
@@ -519,16 +527,30 @@ export async function runGenericOpenAI(ctx: RunContext, signal?: AbortSignal): P
     );
     turns += 1;
 
+    const resolvedModel = readString(data['model']);
+    if (resolvedModel) resolvedModels.add(resolvedModel);
+
     const u = isRecord(data['usage']) ? data['usage'] : null;
     if (u) {
       sawUsage = true;
+      usageTurns += 1;
       const details = isRecord(u['prompt_tokens_details']) ? u['prompt_tokens_details'] : null;
       const cached = num(details ? details['cached_tokens'] : u['cached_tokens']);
+      const cacheWrite = num(details ? details['cache_write_tokens'] : u['cache_write_tokens']);
       // `prompt_tokens` INCLUDES the cached prefix; billing the whole thing at the uncached
       // rate is the 10x overbilling bug from design §5.2.
-      usage.uncachedIn += Math.max(0, num(u['prompt_tokens']) - cached);
+      usage.uncachedIn += Math.max(0, num(u['prompt_tokens']) - cached - cacheWrite);
       usage.cacheRead += cached;
+      usage.cacheWrite += cacheWrite;
       usage.out += num(u['completion_tokens']);
+
+      if (ctx.args['usage_cost'] === 'usd') {
+        const cost = nonNegativeNumber(u['cost']);
+        if (cost !== null) {
+          costedTurns += 1;
+          reportedCostUsd += cost;
+        }
+      }
     }
 
     const choices = data['choices'];
@@ -569,6 +591,13 @@ export async function runGenericOpenAI(ctx: RunContext, signal?: AbortSignal): P
     }
   }
 
+  if (resolvedModels.size > 1) {
+    diagnostics.push(`routing provider returned multiple model identities: ${[...resolvedModels].join(', ')}`);
+  }
+  if (ctx.args['usage_cost'] === 'usd' && usageTurns > costedTurns) {
+    diagnostics.push('provider omitted charged cost for at least one turn — estimating from token usage');
+  }
+
   // The file written through the write_file tool wins; the fenced-block parse of the final
   // message is the fallback for a model that answered in prose instead.
   const file = readReportSafely(ctx.findingsPath);
@@ -586,8 +615,9 @@ export async function runGenericOpenAI(ctx: RunContext, signal?: AbortSignal): P
   return {
     report,
     usage: sawUsage ? usage : null,
-    // No OpenAI-compatible endpoint returns a dollar figure — we always estimate from tokens.
-    reportedCostUsd: null,
+    reportedCostUsd: usageTurns > 0 && costedTurns === usageTurns ? reportedCostUsd : null,
+    ...(resolvedModels.size ? { resolvedModel: [...resolvedModels].join(', ') } : {}),
+    ...(sawUsage ? { usageSource: 'provider' as const } : {}),
     turns,
     truncated,
     rawText,

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -112,8 +112,8 @@ async function dumpIo(scratchDir: string, io: HarnessIO): Promise<void> {
 
 /**
  * `run()` layers its env over `process.env`, so an allowlisted env is not enough on its
- * own: every ambient variable has to be explicitly cleared, or a fan-out of four models
- * hands all four providers all four API keys. Node drops keys whose value is `undefined`.
+ * own: every ambient variable has to be explicitly cleared, or a multi-model fan-out
+ * hands every provider every configured API key. Node drops keys whose value is `undefined`.
  */
 function isolate(env: Record<string, string>): Record<string, string | undefined> {
   const cleared: Record<string, string | undefined> = {};

--- a/src/init.ts
+++ b/src/init.ts
@@ -5,8 +5,8 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { createInterface } from 'node:readline/promises';
 
-import { loadConfig, readSecret } from './config.js';
-import type { HarnessId, JurorConfig, ModelConfig } from './types.js';
+import { applyReviewPreset, loadConfig, readSecret } from './config.js';
+import type { HarnessId, JurorConfig, ModelConfig, ReviewPreset } from './types.js';
 import { run, type RunOptions } from './util/proc.js';
 import { repoRoot } from './util/workspace.js';
 
@@ -48,6 +48,7 @@ const PROVIDERS = [
   { canonicalName: 'JUROR_OPENAI_API_KEY', label: 'OpenAI' },
   { canonicalName: 'JUROR_XAI_API_KEY', label: 'xAI' },
   { canonicalName: 'JUROR_FIREWORKS_API_KEY', label: 'Fireworks' },
+  { canonicalName: 'JUROR_OPENROUTER_API_KEY', label: 'OpenRouter' },
 ] as const;
 
 export interface InitCommandOptions {
@@ -56,6 +57,7 @@ export interface InitCommandOptions {
   env: Record<string, string | undefined>;
   version: string;
   actionSha?: string | null;
+  preset?: ReviewPreset | null;
   dryRun?: boolean;
   setSecrets?: boolean;
   yes?: boolean;
@@ -124,7 +126,11 @@ function modelFamily(model: ModelConfig): string {
   return model.id.toLowerCase();
 }
 
-export function renderManagedWorkflow(options: { actionSha: string; version: string }): string {
+export function renderManagedWorkflow(options: {
+  actionSha: string;
+  version: string;
+  preset?: ReviewPreset | null;
+}): string {
   assertActionSha(options.actionSha);
   const body = `# Juror v${options.version}\n` +
     `# Edit .juror.yml for review policy. Run \`juror init\` to refresh this managed workflow.\n` +
@@ -149,11 +155,13 @@ export function renderManagedWorkflow(options: { actionSha: string; version: str
     `      - uses: juror-ai/juror@${options.actionSha} # v${options.version}\n` +
     `        with:\n` +
     `          github-token: \${{ secrets.GITHUB_TOKEN }}\n` +
+    (options.preset ? `          preset: ${options.preset}\n` : '') +
     `        env:\n` +
     `          JUROR_OPENAI_API_KEY: \${{ secrets.JUROR_OPENAI_API_KEY }}\n` +
     `          JUROR_ANTHROPIC_API_KEY: \${{ secrets.JUROR_ANTHROPIC_API_KEY }}\n` +
     `          JUROR_XAI_API_KEY: \${{ secrets.JUROR_XAI_API_KEY }}\n` +
-    `          JUROR_FIREWORKS_API_KEY: \${{ secrets.JUROR_FIREWORKS_API_KEY }}\n`;
+    `          JUROR_FIREWORKS_API_KEY: \${{ secrets.JUROR_FIREWORKS_API_KEY }}\n` +
+    `          JUROR_OPENROUTER_API_KEY: \${{ secrets.JUROR_OPENROUTER_API_KEY }}\n`;
   const digest = createHash('sha256').update(body).digest('hex');
   return `${MANAGED_PREFIX}${digest}\n${body}`;
 }
@@ -242,7 +250,8 @@ export async function runInitCommand(options: InitCommandOptions): Promise<InitC
   const gh = await inspectGh(runner);
   const defaultBranch = await detectDefaultBranch(root, repo, gh.authenticated, runner);
   const loaded = loadConfig(root);
-  const readiness = credentialReadiness(options.env, loaded.config);
+  const config = options.preset ? applyReviewPreset(loaded.config, options.preset) : loaded.config;
+  const readiness = credentialReadiness(options.env, config);
   const availableNames = readiness.providers
     .filter((provider) => provider.available)
     .map((provider) => provider.canonicalName);
@@ -252,6 +261,7 @@ export async function runInitCommand(options: InitCommandOptions): Promise<InitC
   write(`Default branch: ${defaultBranch}\n`);
   write(`GitHub CLI: ${gh.installed ? (gh.authenticated ? `authenticated${gh.login ? ` as ${gh.login}` : ''}` : 'installed, not authenticated') : 'not installed'}\n`);
   write(`Config: ${loaded.sourcePath ? path.relative(root, loaded.sourcePath) : 'defaults (no .juror.yml found)'}\n`);
+  if (options.preset) write(`Preset: ${options.preset} (CLI override)\n`);
   for (const problem of loaded.problems) write(`  ! Config warning: ${problem}\n`);
   for (const provider of readiness.providers) {
     write(
@@ -275,7 +285,7 @@ export async function runInitCommand(options: InitCommandOptions): Promise<InitC
     );
   }
   const actionSha = await resolveActionSha(options.actionSha, options.version, runner);
-  const workflowText = renderManagedWorkflow({ actionSha, version: options.version });
+  const workflowText = renderManagedWorkflow({ actionSha, version: options.version, preset: options.preset });
   const workflow = await installManagedWorkflow(root, workflowText, options.dryRun ?? false);
   write(`${workflowSummary(workflow, root)}\n`);
 
@@ -301,7 +311,10 @@ export async function runInitCommand(options: InitCommandOptions): Promise<InitC
     write('Existing workflow has user changes and was preserved; merge the generated setup manually.\n');
   } else {
     write(`Next: commit ${path.relative(root, workflow.path)} and open a pull request.\n`);
-    write(`First local review (uses provider APIs): juror review --base ${defaultBranch}\n`);
+    write(
+      `First local review (uses provider APIs): juror review` +
+        `${options.preset ? ` --preset ${options.preset}` : ''} --base ${defaultBranch}\n`,
+    );
   }
 
   return {

--- a/src/render/receipt.ts
+++ b/src/render/receipt.ts
@@ -128,7 +128,9 @@ function headlineAmount(totals: CostTotals): string {
 }
 
 function modelRow(row: CostRow, isSkipped: boolean): string {
-  const model = code(row.label);
+  const model = row.modelRef
+    ? `${cell(row.label)}<br><sub>${cell(row.modelRef)}</sub>`
+    : code(row.label);
   const harness = cell(row.harnessLabel);
   if (isSkipped) {
     return `| ${model} | ${harness} | ${DASH} | ${DASH} | ${DASH} | ${DASH} | *skipped* |`;
@@ -149,7 +151,8 @@ function totalRow(totals: CostTotals): string {
 
 function sourceCell(row: CostRow): string {
   const base = row.cost.source === 'reported' ? 'reported' : `*${row.cost.source}*`;
-  return row.cost.longContext ? `${base}, long-context` : base;
+  const usage = row.usageSource ? ` (${row.usageSource} usage)` : '';
+  return `${base}${row.cost.longContext ? ', long-context' : ''}${usage}`;
 }
 
 function rollingLine(r: RollingSpend): string {

--- a/src/render/summary.ts
+++ b/src/render/summary.ts
@@ -221,6 +221,9 @@ export function renderSummaryComment(r: ReviewResult, o: RenderOptions): string 
   const votes = votesLine(r.verdict);
   if (votes) blocks.push(votes);
 
+  const consensus = consensusAvailability(r);
+  if (consensus) blocks.push(consensus);
+
   const attention = filesNeedingAttention(r.published);
   if (attention) blocks.push(`**Files needing attention:** ${attention}`);
 
@@ -268,6 +271,13 @@ function votesLine(v: Verdict): string {
   if (v.votes.length === 0) return '';
   const votes = v.votes.map((x) => `${mdCell(x.modelLabel)} \`${x.vote}\``).join(' · ');
   return `<sub>Model votes: ${votes} → median **${trimNum(v.base)}**${capClause(v)}.</sub>`;
+}
+
+function consensusAvailability(r: ReviewResult): string {
+  const configured = r.runs.length;
+  const completed = r.runs.filter((run) => run.ok && run.result?.report).length;
+  if (configured < 2 || completed >= 2) return '';
+  return `**⚠ Cross-model consensus unavailable: only ${completed} of ${configured} configured jurors completed.**`;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,6 +213,10 @@ export interface HarnessResult {
   usage: CanonicalUsage | null;
   /** Provider-computed cost. `null` means we must estimate from tokens. */
   reportedCostUsd: number | null;
+  /** Actual model identity returned by a routing provider, when available. */
+  resolvedModel?: string;
+  /** Where normalized token counts came from. */
+  usageSource?: 'provider' | 'harness';
   turns: number;
   truncated: boolean;
   /** Final assistant text, kept for debugging and fenced-block fallback parsing. */
@@ -415,7 +419,7 @@ export interface ModelConfig {
   max_turns?: number;
 }
 
-export type ReviewPreset = 'fast' | 'balanced' | 'high' | 'ultra';
+export type ReviewPreset = 'starter' | 'fast' | 'balanced' | 'high' | 'ultra';
 
 export interface JurorConfig {
   version: 1;
@@ -484,8 +488,11 @@ export interface ReviewSummary {
 
 export interface CostRow {
   label: string;
+  /** Actual provider-returned model identity, when it differs from the display label. */
+  modelRef?: string;
   harnessLabel: string;
   usage: CanonicalUsage | null;
+  usageSource?: 'provider' | 'harness';
   cost: CostBreakdown;
 }
 

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -63,6 +63,7 @@ export const log = {
 const SECRET_PATTERNS: RegExp[] = [
   /\bsk-ant-api\d{2}-[A-Za-z0-9_-]{20,}/g,
   /\bsk-proj-[A-Za-z0-9_-]{20,}/g,
+  /\bsk-or-v1-[A-Za-z0-9_-]{20,}/g,
   /\bsk-[A-Za-z0-9]{32,}/g,
   /\bxai-[A-Za-z0-9]{20,}/g,
   /\bfw_[A-Za-z0-9]{16,}/g,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -74,13 +74,32 @@ describe('defaultConfig', () => {
     expect(b.models[0]?.args?.['reasoning_effort']).toBe('low');
   });
 
-  it('ships the requested fast, balanced, high, and ultra preset memberships', () => {
+  it('ships the opt-in one-secret starter and the direct-provider presets', () => {
     const base = defaultConfig();
+    const starter = applyReviewPreset(base, 'starter');
     const fast = applyReviewPreset(base, 'fast');
     const balanced = applyReviewPreset(base, 'balanced');
     const high = applyReviewPreset(base, 'high');
     const ultra = applyReviewPreset(base, 'ultra');
 
+    expect(starter.models).toMatchObject([
+      {
+        id: 'openrouter-gpt-5.6-luna',
+        harness: 'generic-openai',
+        secret: 'JUROR_OPENROUTER_API_KEY',
+        harness_model: 'openai/gpt-5.6-luna',
+        base_url: 'https://openrouter.ai/api/v1',
+      },
+      {
+        id: 'openrouter-deepseek-v4-flash',
+        harness: 'generic-openai',
+        secret: 'JUROR_OPENROUTER_API_KEY',
+        harness_model: 'deepseek/deepseek-v4-flash-0731',
+        base_url: 'https://openrouter.ai/api/v1',
+      },
+    ]);
+    expect(starter.models.every((model) => model.args?.['usage_cost'] === 'usd')).toBe(true);
+    expect(starter.consensus.referee_model).toBe('openrouter-deepseek-v4-flash');
     expect(fast.models.map((m) => m.id)).toEqual(['gpt-5.6-luna', 'deepseek-v4-flash-0731']);
     expect(fast.models.map((m) => m.args?.['reasoning_effort'] ?? m.args?.['variant'])).toEqual(['low', 'low']);
     expect(fast.consensus.referee_model).toBe('deepseek-v4-flash-0731');
@@ -265,7 +284,7 @@ describe('loadConfig', () => {
     const { config, problems } = loadConfig(dir);
     expect(config).toEqual(defaultConfig());
     expect(problems).toHaveLength(1);
-    expect(problems[0]).toContain('expected one of fast, balanced, high, ultra');
+    expect(problems[0]).toContain('expected one of starter, fast, balanced, high, ultra');
   });
 
   it('falls back to the default and reports a problem for an out-of-range number', () => {

--- a/test/cost.test.ts
+++ b/test/cost.test.ts
@@ -55,6 +55,16 @@ describe('pricing.json', () => {
     expect(pricing['gpt-5.6-terra']?.long_context?.output_per_mtok).toBe(22.5);
     expect(pricing['claude-opus-5']?.cache_write_per_mtok).toBe(6.25);
     expect(pricing['accounts/fireworks/models/deepseek-v4-flash-0731']?.input_per_mtok).toBe(0.14);
+    expect(pricing['openrouter/openai/gpt-5.6-luna-20260709']).toMatchObject({
+      input_per_mtok: 0.1,
+      cache_read_per_mtok: 0.01,
+      output_per_mtok: 0.6,
+    });
+    expect(pricing['openrouter/deepseek/deepseek-v4-flash-20260731']).toMatchObject({
+      input_per_mtok: 0.08,
+      cache_read_per_mtok: 0.016,
+      output_per_mtok: 0.18,
+    });
     expect(pricing['accounts/fireworks/models/kimi-k3']).toMatchObject({
       input_per_mtok: 3,
       cache_read_per_mtok: 0.3,
@@ -133,6 +143,18 @@ describe('computeCost rule 2 — never guess', () => {
     });
     expect(cost.usd).toBeNull();
     expect(cost.source).toBe('unknown');
+  });
+
+  it('uses the pinned OpenRouter rate only when provider-charged cost is absent', () => {
+    const cost = computeCost({
+      pricingKey: 'openrouter/deepseek/deepseek-v4-flash-20260731',
+      usage: usage({ uncachedIn: 1_000_000, cacheRead: 500_000, out: 1_000_000 }),
+      reportedCostUsd: null,
+      pricing,
+      turns: 2,
+    });
+
+    expect(cost).toMatchObject({ usd: 0.268, source: 'estimated', longContext: false });
   });
 });
 

--- a/test/generic-openai.test.ts
+++ b/test/generic-openai.test.ts
@@ -60,6 +60,39 @@ function completion(message: Record<string, unknown>): Response {
 }
 
 describe('generic OpenAI turn budget', () => {
+  it('reports the resolved model plus native usage, cache writes, and provider-charged cost', async () => {
+    const ctx = context(0);
+    ctx.providerKey = 'openrouter-key';
+    ctx.model = 'openai/gpt-5.6-luna';
+    ctx.args = { usage_cost: 'usd' };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            model: 'openai/gpt-5.6-luna',
+            choices: [{ message: { role: 'assistant', content: JSON.stringify(REPORT) } }],
+            usage: {
+              prompt_tokens: 100,
+              completion_tokens: 7,
+              prompt_tokens_details: { cached_tokens: 20, cache_write_tokens: 10 },
+              cost: 0.0123,
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    );
+
+    const result = await runGenericOpenAI(ctx);
+
+    expect(result.resolvedModel).toBe('openai/gpt-5.6-luna');
+    expect(result.usageSource).toBe('provider');
+    expect(result.usage).toEqual({ uncachedIn: 70, cacheRead: 20, cacheWrite: 10, out: 7 });
+    expect(result.reportedCostUsd).toBe(0.0123);
+    expect(JSON.stringify(result)).not.toContain('openrouter-key');
+  });
+
   it('uses the runner-resolved provider key when passthrough env makes inference ambiguous', async () => {
     const ctx = context(0);
     ctx.providerKey = 'resolved-provider-key';
@@ -73,6 +106,43 @@ describe('generic OpenAI turn budget', () => {
 
     const headers = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>;
     expect(headers['authorization']).toBe('Bearer resolved-provider-key');
+  });
+
+  it('does not present a partial provider charge as the complete reported cost', async () => {
+    const ctx = context(0);
+    ctx.args = { usage_cost: 'usd' };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          model: 'first/model',
+          choices: [{ message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [{
+              id: 'call-1',
+              type: 'function',
+              function: { name: 'list_dir', arguments: JSON.stringify({ path: '.' }) },
+            }],
+          } }],
+          usage: { prompt_tokens: 10, completion_tokens: 2, cost: 0.001 },
+        }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          model: 'first/model',
+          choices: [{ message: { role: 'assistant', content: JSON.stringify(REPORT) } }],
+          usage: { prompt_tokens: 20, completion_tokens: 3 },
+        }), { status: 200 }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await runGenericOpenAI(ctx);
+
+    expect(result.reportedCostUsd).toBeNull();
+    expect(result.diagnostics).toContain(
+      'provider omitted charged cost for at least one turn — estimating from token usage',
+    );
   });
 
   it('continues past one tool round when zero disables the step cap', async () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { defaultConfig } from '../src/config.js';
+import { applyReviewPreset, defaultConfig } from '../src/config.js';
 import {
   credentialReadiness,
   installManagedWorkflow,
@@ -66,6 +66,12 @@ describe('credentialReadiness', () => {
         available: true,
         source: 'FIREWORKS_API_KEY',
       },
+      {
+        canonicalName: 'JUROR_OPENROUTER_API_KEY',
+        label: 'OpenRouter',
+        available: false,
+        source: 'JUROR_OPENROUTER_API_KEY',
+      },
     ]);
     expect(readiness.runnableModels).toEqual(['gpt-5.6-luna', 'deepseek-v4-flash-0731']);
     expect(readiness.juryKind).toBe('multi-model');
@@ -82,6 +88,21 @@ describe('credentialReadiness', () => {
     expect(readiness.runnableModels).toEqual(['gpt-5.6-luna']);
     expect(readiness.juryKind).toBe('single-model');
   });
+
+  it('recognizes two independent starter families from one OpenRouter credential', () => {
+    const readiness = credentialReadiness(
+      { JUROR_OPENROUTER_API_KEY: 'one-aggregator-secret' },
+      applyReviewPreset(defaultConfig(), 'starter'),
+    );
+
+    expect(readiness.runnableModels).toEqual([
+      'openrouter-gpt-5.6-luna',
+      'openrouter-deepseek-v4-flash',
+    ]);
+    expect(readiness.runnableFamilies).toEqual(['openai', 'deepseek']);
+    expect(readiness.juryKind).toBe('multi-model');
+    expect(JSON.stringify(readiness)).not.toContain('one-aggregator-secret');
+  });
 });
 
 describe('managed workflow', () => {
@@ -96,6 +117,7 @@ describe('managed workflow', () => {
     );
     expect(workflow).not.toContain('juror-ai/juror@v1');
     expect(workflow).not.toContain('actions/checkout@v4');
+    expect(workflow).toContain('JUROR_OPENROUTER_API_KEY: ${{ secrets.JUROR_OPENROUTER_API_KEY }}');
     expect(workflow).toContain('# juror:init:managed sha256:');
     expect(managedWorkflowIsPristine(workflow)).toBe(true);
   });
@@ -206,6 +228,28 @@ describe('uploadProviderSecrets', () => {
       ),
     ).rejects.toThrow('Unsupported Juror provider secret');
   });
+
+  it('uploads an OpenRouter key through stdin under the dedicated name', async () => {
+    const calls: { argv: string[]; opts: RunOptions }[] = [];
+    const runner = vi.fn(async (argv: string[], opts: RunOptions = {}) => {
+      calls.push({ argv, opts });
+      return { stdout: '', stderr: '', exitCode: 0, signal: null, durationMs: 1, timedOut: false };
+    });
+
+    await expect(
+      uploadProviderSecrets(
+        { OPENROUTER_API_KEY: 'aggregator-value' },
+        ['JUROR_OPENROUTER_API_KEY'],
+        'owner/repo',
+        runner,
+      ),
+    ).resolves.toEqual(['JUROR_OPENROUTER_API_KEY']);
+    expect(calls).toEqual([{
+      argv: ['gh', 'secret', 'set', 'JUROR_OPENROUTER_API_KEY', '--repo', 'owner/repo'],
+      opts: { stdin: 'aggregator-value', timeoutMs: 120_000 },
+    }]);
+    expect(JSON.stringify(calls.map((call) => call.argv))).not.toContain('aggregator-value');
+  });
 });
 
 describe('juror init CLI', () => {
@@ -270,5 +314,37 @@ describe('juror init CLI', () => {
 
     expect(result.status).not.toBe(0);
     expect(() => readFileSync(join(repo, '.github/workflows/juror.yml'), 'utf8')).toThrow();
+  });
+
+  it('persists an explicit starter preset and reports a one-key multi-model jury', () => {
+    const repo = tempRepo();
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repo });
+    execFileSync('git', ['remote', 'add', 'origin', 'git@github.com:owner/example.git'], { cwd: repo });
+    writeFileSync(join(repo, '.env'), 'JUROR_OPENROUTER_API_KEY=test-only-value\n', 'utf8');
+
+    const output = execFileSync(
+      join(process.cwd(), 'node_modules', '.bin', 'vite-node'),
+      [
+        join(process.cwd(), 'src/cli.ts'),
+        'init',
+        '--repo-dir',
+        repo,
+        '--preset',
+        'starter',
+        '--action-sha',
+        'b'.repeat(40),
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        env: { PATH: process.env.PATH, HOME: process.env.HOME, NO_COLOR: '1' },
+      },
+    );
+
+    expect(output).toContain('Preset: starter (CLI override)');
+    expect(output).toContain('2 runnable models across 2 families');
+    expect(output).not.toContain('test-only-value');
+    const workflow = readFileSync(join(repo, '.github/workflows/juror.yml'), 'utf8');
+    expect(workflow).toContain('preset: starter');
   });
 });

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -23,6 +23,12 @@ describe('redact', () => {
     expect(redact('sk-proj-tooshort')).toBe('sk-proj-tooshort');
   });
 
+  it('redacts OpenRouter keys and leaves short tails alone', () => {
+    const key = 'sk-or-v1-' + 'R'.repeat(20);
+    expect(redact(`OPENROUTER_API_KEY=${key}`)).toBe('OPENROUTER_API_KEY=[redacted]');
+    expect(redact('sk-or-v1-short')).toBe('sk-or-v1-short');
+  });
+
   it('redacts generic sk- keys (32+ alnum) without eating shorter tokens', () => {
     const key = 'sk-' + 'c'.repeat(32);
     expect(redact(`export OPENAI_API_KEY=${key}`)).toBe('export OPENAI_API_KEY=[redacted]');

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -652,6 +652,43 @@ describe('renderReceipt', () => {
     expect(md.trimEnd().endsWith('</details>')).toBe(true);
   });
 
+  it('shows the actual routed model and provider usage source in a receipt', () => {
+    const t = totals({
+      rows: [{
+        label: 'GPT-5.6 Luna',
+        modelRef: 'openai/gpt-5.6-luna',
+        harnessLabel: 'Generic OpenAI',
+        usageSource: 'provider',
+        usage: { uncachedIn: 100, cacheRead: 20, cacheWrite: 10, out: 7 },
+        cost: { usd: 0.0123, source: 'reported', longContext: false },
+      }],
+      usage: { uncachedIn: 100, cacheRead: 20, cacheWrite: 10, out: 7 },
+      usd: 0.0123,
+      modelsRun: 1,
+    });
+
+    const md = renderReceipt(t, { durationMs: 1_000 });
+
+    expect(md).toContain('GPT-5.6 Luna<br><sub>openai/gpt-5.6-luna</sub>');
+    expect(md).toContain('| Generic OpenAI | 100 | 30 | 7 | $0.01 | reported (provider usage) |');
+  });
+
+  it('states that cross-model consensus is unavailable when only one juror completes', () => {
+    const failed = run({
+      modelId: 'deepseek',
+      modelLabel: 'DeepSeek V4 Flash',
+      ok: false,
+      result: null,
+      cost: { usd: null, source: 'unknown', longContext: false },
+      error: 'provider unavailable',
+    }, null);
+    const r = result({ runs: [run(), failed], totals: totals({ modelsRun: 1 }) });
+
+    expect(renderSummaryComment(r, opts)).toContain(
+      'Cross-model consensus unavailable: only 1 of 2 configured jurors completed.',
+    );
+  });
+
   it('calls a partial total a lower bound and names the unknown rows', () => {
     const t = totals({
       rows: [

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -1,7 +1,22 @@
-import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { harnessScratch, runHarness, shouldRetryEmptyRun } from '../src/harness/runner.js';
+import { applyReviewPreset, defaultConfig } from '../src/config.js';
+import { loadPricing } from '../src/cost/compute.js';
+import { fanOut, harnessScratch, runHarness, shouldRetryEmptyRun } from '../src/harness/runner.js';
 import type { Harness, HarnessResult, RunContext } from '../src/types.js';
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  while (dirs.length) {
+    const dir = dirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe('harnessScratch', () => {
   it('separates model ids that normalize to the same filesystem slug', () => {
@@ -86,5 +101,71 @@ describe('runHarness lifecycle', () => {
     expect(result.report).toBeNull();
     expect(result.diagnostics.join(' ')).toContain('startup failed');
     expect(cleaned).toBe(true);
+  });
+});
+
+describe('starter fan-out', () => {
+  it('runs two isolated model families with one key and keeps charged cost per model', async () => {
+    const repoDir = mkdtempSync(join(tmpdir(), 'juror-starter-repo-'));
+    const scratchRoot = mkdtempSync(join(tmpdir(), 'juror-starter-scratch-'));
+    dirs.push(repoDir, scratchRoot);
+    const secret = 'one-openrouter-key';
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { model: string };
+      return new Response(JSON.stringify({
+        model: body.model,
+        choices: [{ message: { role: 'assistant', content: JSON.stringify({
+          merge_confidence: 5,
+          confidence_reason: 'No defect found.',
+          summary: 'Reviewed.',
+          highlights: [],
+          file_overviews: [],
+          async_contracts: [],
+          sequence_diagram: null,
+          findings: [],
+        }) } }],
+        usage: { prompt_tokens: 100, completion_tokens: 10, cost: 0.001 },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const runs = await fanOut({
+      config: applyReviewPreset(defaultConfig(), 'starter'),
+      diff: {
+        patch: '',
+        files: [],
+        baseSha: 'b'.repeat(40),
+        headSha: 'a'.repeat(40),
+        sinceSha: null,
+        totalAdditions: 0,
+        totalDeletions: 0,
+        ignoredPaths: [],
+        truncated: false,
+      },
+      repoDir,
+      scratchRoot,
+      promptTemplate: 'Review the repository and return the report.',
+      promptVars: {},
+      pricing: loadPricing(),
+      secrets: { JUROR_OPENROUTER_API_KEY: secret },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(runs.map((run) => run.ok)).toEqual([true, true]);
+    expect(runs.map((run) => run.result?.resolvedModel)).toEqual([
+      'openai/gpt-5.6-luna',
+      'deepseek/deepseek-v4-flash-0731',
+    ]);
+    expect(runs.map((run) => run.cost)).toEqual([
+      { usd: 0.001, source: 'reported', longContext: false },
+      { usd: 0.001, source: 'reported', longContext: false },
+    ]);
+    expect(readdirSync(scratchRoot)).toHaveLength(2);
+    for (const call of fetchMock.mock.calls) {
+      const headers = call[1]?.headers as Record<string, string>;
+      expect(headers.authorization).toBe(`Bearer ${secret}`);
+      expect(String(call[1]?.body)).not.toContain(secret);
+    }
+    expect(JSON.stringify(runs)).not.toContain(secret);
   });
 });

--- a/test/supply-chain.test.ts
+++ b/test/supply-chain.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
 
 import { releaseIdentityErrors } from '../scripts/verify-release.mjs';
 
@@ -51,6 +52,19 @@ describe('supply-chain policy', () => {
 
     expect(config).toContain('package-ecosystem: npm');
     expect(config).toContain('package-ecosystem: github-actions');
+  });
+
+  it('keeps the OpenRouter key away from setup, cache, build, and installer steps', () => {
+    const action = parse(read('action.yml')) as {
+      runs: { steps: { name?: string; env?: Record<string, string> }[] };
+    };
+    const reviewIndex = action.runs.steps.findIndex((step) => step.name === 'Review');
+
+    expect(reviewIndex).toBeGreaterThan(0);
+    for (const step of action.runs.steps.slice(0, reviewIndex)) {
+      expect(step.env?.['JUROR_OPENROUTER_API_KEY'], step.name).toBe('');
+      expect(step.env?.['OPENROUTER_API_KEY'], step.name).toBe('');
+    }
   });
 
   it('publishes only a matching tag and produces verifiable release artifacts', () => {


### PR DESCRIPTION
## Summary

- add an opt-in `starter` preset that runs GPT-5.6 Luna and DeepSeek V4 Flash through OpenRouter with one `JUROR_OPENROUTER_API_KEY`
- preserve isolated generic-harness scratch spaces and credential boundaries, with explicit single-reviewer consensus degradation
- record provider-returned model identities, usage provenance, and complete-or-fallback cost accounting in receipts
- document direct first-party credentials as the higher-control path and retain `fast` as the default pending the seed benchmark

## Validation

- `npm run typecheck`
- `npm test` (384 tests)
- `npm run build`
- `npm run check:secure-refs`
- `npm pack --dry-run`
- YAML parse and `git diff --check`

Refs #41

## Remaining acceptance gate

A real `starter` vs `fast` seed-corpus benchmark requires an OpenRouter credential, which is not available in this environment. This PR deliberately leaves `starter` opt-in and does not close #41 until that benchmark is recorded.