### PR TITLE
feat(harness): add native DeepSeek runtime

### DIFF
--- a/.github/ISSUE_TEMPLATE/model-integration.yml
+++ b/.github/ISSUE_TEMPLATE/model-integration.yml
@@ -34,6 +34,7 @@ body:
         - generic-openai
         - grok-build
         - kimi-code
+        - deepseek
         - opencode
         - New harness required
     validations:

--- a/README.md
+++ b/README.md
@@ -266,22 +266,23 @@ file boundary without installing another executable.
 |---|---|---|---|---|
 | `claude-code` | `claude -p` | any Anthropic model | ✅ `total_cost_usd` | tool removal |
 | `codex` | `codex exec` | any OpenAI model | ❌ → estimated | split filesystem profile (kernel) |
+| `deepseek` | `codewhale exec` | DeepSeek models | ❌ → estimated from provider usage | read-only sandbox + tool allowlist |
 | `opencode` | `opencode run` | anything on [models.dev](https://models.dev) — Fireworks, Groq, OpenRouter, … | ✅ per-step `cost` | tool removal |
 | `grok-build` | `grok -p` | Grok models | ✅ `total_cost_usd` | Landlock |
 | `kimi-code` | `kimi -p` | Kimi K3 on Fireworks | ❌ → estimated from session usage | tool allowlist + isolated runtime |
 | `generic-openai` | *(in-process)* | any OpenAI-compatible endpoint | provider-reported when documented; otherwise estimated | path-confined tools |
 
-The `opencode` harness is the reason adding a model is a config edit rather than a PR. To add
-**DeepSeek V4 Flash** to your jury:
+DeepSeek models use the DeepSeek-native CodeWhale harness so interleaved reasoning survives
+tool calls. To add **DeepSeek V4 Flash** on Fireworks to your jury:
 
 ```yaml
 models:
   - id: deepseek-v4-flash-0731
-    harness: opencode
-    harness_model: fireworks-ai/accounts/fireworks/models/deepseek-v4-flash-0731
+    harness: deepseek
+    harness_model: accounts/fireworks/models/deepseek-v4-flash-0731
     pricing_key: accounts/fireworks/models/deepseek-v4-flash-0731
     secret: JUROR_FIREWORKS_API_KEY
-    args: { variant: high }
+    args: { reasoning_effort: high }
 ```
 
 ---
@@ -294,7 +295,7 @@ Juror ships five jury presets. Models whose provider key is unavailable are skip
 | Preset | Jury | Intended use |
 |---|---|---|
 | `starter` *(opt-in)* | GPT-5.6 Luna · DeepSeek V4 Flash through OpenRouter's confined generic harness | Two model families from one `JUROR_OPENROUTER_API_KEY`; awaiting benchmark promotion gate |
-| `fast` **(default)** | GPT-5.6 Luna via Codex/OpenAI (`low`) · DeepSeek V4 Flash via opencode/Fireworks (`low`) | Smallest, cheapest jury |
+| `fast` **(default)** | GPT-5.6 Luna via Codex/OpenAI (`low`) · DeepSeek V4 Flash via DeepSeek/Fireworks (`high`) | Lean two-model jury |
 | `balanced` | GPT-5.6 Terra via Codex/OpenAI (`max`) · Grok 4.5 via Grok Build/xAI (`high`) · Kimi K3 via Kimi Code/Fireworks (`max`) | Strong provider diversity without the full burn |
 | `high` | GPT-5.6 Sol via Codex/OpenAI (`high`) · Opus 5 via Claude Code/Anthropic · Grok 4.5 via Grok Build/xAI (`high`) | Higher-confidence frontier jury |
 | `ultra` | Every model from the other presets (seven total), using their higher reasoning settings | Maximum coverage; highest token and cost use |
@@ -445,7 +446,7 @@ It is designed for that.
    filesystem profile that exposes only runtime files, the sealed checkout, and Juror scratch;
    its model-controlled shells inherit no process environment or shell snapshot, so the
    provider credential remains available to the Codex client but not to commands it runs.
-   Claude, Grok Build, opencode, and Kimi receive read/search tools only. Generic OpenAI
+   Claude, DeepSeek, Grok Build, opencode, and Kimi receive read/search tools only. Generic OpenAI
    resolves symlinks and may write only one exact report path outside the repository. Claude,
    Codex, and Kimi start from private temporary directories so PR-controlled hooks, MCP,
    settings, and `AGENTS.md` are not auto-loaded. Every run reads a detached checkout that

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: npm version spec for Codex CLI. Must be >= 0.146.0 for cache-write accounting.
     required: false
     default: '@openai/codex@0.146.1'
+  deepseek-version:
+    description: npm version spec for the DeepSeek-native CodeWhale CLI.
+    required: false
+    default: 'codewhale@0.9.7'
   opencode-version:
     description: npm version spec for opencode.
     required: false
@@ -161,6 +165,7 @@ runs:
       env:
         CLAUDE_CODE_SPEC: ${{ inputs.claude-code-version }}
         CODEX_SPEC: ${{ inputs.codex-version }}
+        DEEPSEEK_SPEC: ${{ inputs.deepseek-version }}
         OPENCODE_SPEC: ${{ inputs.opencode-version }}
         KIMI_CODE_SPEC: ${{ inputs.kimi-code-version }}
         JUROR_OPENROUTER_API_KEY: ''
@@ -174,7 +179,7 @@ runs:
         [ -n "$HAS_ANTHROPIC" ] && SPECS+=("$CLAUDE_CODE_SPEC")
         [ -n "$HAS_OPENAI" ] && SPECS+=("$CODEX_SPEC")
         if [ -n "$HAS_FIREWORKS" ]; then
-          SPECS+=("$OPENCODE_SPEC" "$KIMI_CODE_SPEC")
+          SPECS+=("$DEEPSEEK_SPEC" "$OPENCODE_SPEC" "$KIMI_CODE_SPEC")
         fi
         if [ "${#SPECS[@]}" -eq 0 ]; then
           echo "enabled=false" >> "$GITHUB_OUTPUT"
@@ -205,12 +210,13 @@ runs:
         key: ${{ steps.harness-cache-key.outputs.key }}
 
     # Only harnesses backed by an available provider are installed. Fireworks supplies
-    # both the opencode models and Kimi K3 through Kimi Code.
+    # DeepSeek through CodeWhale, custom opencode models, and Kimi K3 through Kimi Code.
     - name: Install harnesses
       shell: bash
       env:
         CLAUDE_CODE_SPEC: ${{ inputs.claude-code-version }}
         CODEX_SPEC: ${{ inputs.codex-version }}
+        DEEPSEEK_SPEC: ${{ inputs.deepseek-version }}
         OPENCODE_SPEC: ${{ inputs.opencode-version }}
         KIMI_CODE_SPEC: ${{ inputs.kimi-code-version }}
         HARNESS_ROOT: ${{ runner.temp }}/juror-harnesses
@@ -234,6 +240,7 @@ runs:
         }
         [ -n "$HAS_ANTHROPIC" ] && install_harness claude "$CLAUDE_CODE_SPEC"
         [ -n "$HAS_OPENAI"    ] && install_harness codex "$CODEX_SPEC"
+        [ -n "$HAS_FIREWORKS" ] && install_harness codewhale "$DEEPSEEK_SPEC"
         [ -n "$HAS_FIREWORKS" ] && install_harness opencode "$OPENCODE_SPEC"
         [ -n "$HAS_FIREWORKS" ] && install_harness kimi "$KIMI_CODE_SPEC"
         echo "$HARNESS_ROOT/bin" >> "$GITHUB_PATH"

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -14,7 +14,7 @@ Pricing table last checked: **2026-08-11**.
 | Model | Provider / Juror secret | Harness | Provider route | Presets | Cost accounting | Pricing evidence |
 |---|---|---|---|---|---|---|
 | Opus 5<br><sub>`claude-opus-5`</sub> | Anthropic<br><sub>`JUROR_ANTHROPIC_API_KEY`</sub> | Claude Code<br><sub>`claude-code`</sub> | `claude-opus-5` | `high`, `ultra` | provider-reported; unknown on malformed output | [2026-08-06](https://www.anthropic.com/pricing#api) |
-| DeepSeek V4 Flash<br><sub>`deepseek-v4-flash-0731`</sub> | Fireworks<br><sub>`JUROR_FIREWORKS_API_KEY`</sub> | opencode<br><sub>`opencode`</sub> | `fireworks-ai/accounts/fireworks/models/deepseek-v4-flash-0731` | `fast`, `ultra` | provider-reported per step; unknown on malformed output | [2026-08-06](https://models.dev) |
+| DeepSeek V4 Flash<br><sub>`deepseek-v4-flash-0731`</sub> | Fireworks<br><sub>`JUROR_FIREWORKS_API_KEY`</sub> | DeepSeek<br><sub>`deepseek`</sub> | `accounts/fireworks/models/deepseek-v4-flash-0731` | `fast`, `ultra` | provider-usage estimated; unknown without usage events | [2026-08-06](https://models.dev) |
 | GPT-5.6 Luna<br><sub>`gpt-5.6-luna`</sub> | OpenAI<br><sub>`JUROR_OPENAI_API_KEY`</sub> | Codex<br><sub>`codex`</sub> | `gpt-5.6-luna` | `fast`, `ultra` | token-estimated; unknown without usage | [2026-08-07](https://developers.openai.com/api/docs/models/gpt-5.6-luna) |
 | GPT-5.6 Sol<br><sub>`gpt-5.6-sol`</sub> | OpenAI<br><sub>`JUROR_OPENAI_API_KEY`</sub> | Codex<br><sub>`codex`</sub> | `gpt-5.6-sol` | `high`, `ultra` | token-estimated; unknown without usage | [2026-08-06](https://openai.com/api/pricing/) |
 | GPT-5.6 Terra<br><sub>`gpt-5.6-terra`</sub> | OpenAI<br><sub>`JUROR_OPENAI_API_KEY`</sub> | Codex<br><sub>`codex`</sub> | `gpt-5.6-terra` | `balanced`, `ultra` | token-estimated; unknown without usage | [2026-08-06](https://developers.openai.com/api/docs/models/gpt-5.6-terra) |
@@ -29,6 +29,7 @@ Pricing table last checked: **2026-08-11**.
 |---|---|---|---|
 | Claude Code<br><sub>`claude-code`</sub> | `ANTHROPIC_API_KEY` | private runtime; `Read`, `Grep`, and `Glob` only | provider-reported; unknown on malformed output |
 | Codex<br><sub>`codex`</sub> | `OPENAI_API_KEY` | kernel profile; sealed checkout read-only; minimal tool environment | token-estimated; unknown without usage |
+| DeepSeek<br><sub>`deepseek`</sub> | `FIREWORKS_API_KEY` | private runtime; workspace-confined read/search tools; read-only sandbox | provider-usage estimated; unknown without usage events |
 | Generic OpenAI<br><sub>`generic-openai`</sub> | `OPENAI_API_KEY` | in-process path-confined read/search tools; one exact report write | provider-reported only when declared; estimated or unknown fallback |
 | Grok Build<br><sub>`grok-build`</sub> | `XAI_API_KEY` | private runtime and kernel profile; no MCP, web, memory, or subagents | provider-reported when present; unknown otherwise |
 | Kimi Code CLI<br><sub>`kimi-code`</sub> | `FIREWORKS_API_KEY` | private runtime; `Read`, `Grep`, and `Glob` only | usage-estimated; unknown without usage records |

--- a/docs/harness-notes.md
+++ b/docs/harness-notes.md
@@ -9,8 +9,9 @@ disagrees with this file, re-measure before changing anything.**
 Measured 2026-08-06 against: `claude` 2.1.223 · `codex-cli` 0.146.1 · `grok` 0.2.118 ·
 `opencode` 1.17.20.
 
-Source-inspected (no paid provider run) against: `@moonshot-ai/kimi-code` 0.34.0
-and the in-process `generic-openai` adapter in `src/harness/generic-openai.ts`. Their
+Source-inspected (no paid provider run) against: CodeWhale 0.9.7 (the renamed
+DeepSeek-TUI), `@moonshot-ai/kimi-code` 0.34.0, and the in-process `generic-openai`
+adapter in `src/harness/generic-openai.ts`. Their
 sections below name that distinction rather than presenting inferred usage as measured.
 
 `timeout(1)` does not exist on macOS, so every time limit is enforced in Node by
@@ -97,6 +98,50 @@ JSONL on stdout: `thread.started`, `turn.started`, `item.started`, `item.complet
   is not auto-discovered; trusted base-revision rules are already embedded in the prompt.
 - Resolve the binary's absolute path and assert `--version`: multiple installs shadowing each
   other by PATH order is a real, observed failure (0.132.0 in one prefix, 0.146.1 in another).
+
+## DeepSeek — CodeWhale `exec --output-format stream-json`
+
+**Source-inspected, no paid provider run**, against CodeWhale 0.9.7 at upstream commit
+`5e3ac84c5cb925b4c90c34dfe582b75f04605cb1`. DeepSeek-TUI was renamed to CodeWhale in
+0.9.0; the `deepseek-tui` npm package is now a deprecation-only stub, so the Action pins
+`codewhale@0.9.7` and invokes its `codewhale` binary.
+
+```text
+HOME="$PRIVATE_HOME" CODEWHALE_HOME="$PRIVATE_STATE" \
+CODEWHALE_TELEMETRY=0 CODEWHALE_NO_UPDATE_CHECK=1 \
+FIREWORKS_API_KEY="$KEY" \
+  codewhale --config "$PRIVATE_CONFIG" --no-project-config --skip-onboarding \
+    --provider fireworks --model accounts/fireworks/models/deepseek-v4-flash-0731 \
+    -C "$PRIVATE_WORKSPACE" exec --sandbox read-only --output-format stream-json \
+    --allowed-tools read,list_dir,grep_files,file_search \
+    --reasoning-effort low \
+    "Read $SCRATCH/prompt.md completely … review $REPO …" < /dev/null
+```
+
+- CodeWhale 0.9.7 has no prompt-file flag. Juror points the short argv prompt at its existing
+  scratch `prompt.md`; the prompt itself never enters argv, avoiding OS argument limits.
+- The CLI runs with an explicit private `HOME`, `CODEWHALE_HOME`, config, empty skills/tool
+  directories, and empty MCP config. Project configuration is disabled. Telemetry and update
+  checks are disabled both in config and environment.
+- CodeWhale unconditionally imports project instructions from its workspace, even with
+  `--no-project-config`. Juror therefore starts it in a private, trusted empty workspace and
+  writes a private workspace-trust map granting its native path guard only the sealed checkout
+  and this run's scratch directory. Head-revision `AGENTS.md` remains review data instead of
+  becoming system policy.
+- Do **not** add `--auto`: in 0.9.7 it couples tool approval to `trust_mode`, and native file
+  reads can then escape the workspace. `approval_policy = "auto"` autonomously approves safe
+  reads without enabling trust mode. `--allowed-tools` admits only `read`, `list_dir`,
+  `grep_files`, and `file_search`; `[tools].always_load` activates the three deferred search
+  tools. `--sandbox read-only` and `allow_shell = false` remain independent mutation gates.
+- Fireworks is selected explicitly, so the provider model id is
+  `accounts/fireworks/models/deepseek-v4-flash-0731` and the only credential visible to the
+  process is `FIREWORKS_API_KEY`. `base_url` is forwarded as `CODEWHALE_BASE_URL`.
+- Stdout is NDJSON. Concatenate `content` events for the final answer. Each provider request
+  emits `turn_usage` with total input/output plus reported cache hit, miss, and write fields;
+  Juror sums those per-call receipts and estimates cost from its checked-in Fireworks rates.
+  A missing usage event remains unknown rather than `$0.00`.
+- The terminal `metadata` event supplies the resolved model and status. Timeouts, nonzero
+  exits, `error` events, and non-completed terminal statuses all mark the result partial.
 
 ## opencode — `opencode run --format json`
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -50,7 +50,7 @@ advisory and must not be treated as authorization to merge, deploy, or execute c
 
 ## External executables
 
-Juror orchestrates Claude Code, Codex, opencode, Grok Build, and Kimi Code. These programs are
+Juror orchestrates Claude Code, Codex, CodeWhale for DeepSeek, opencode, Grok Build, and Kimi Code. These programs are
 outside Juror's trust boundary: they parse untrusted model and repository data and may make
 network requests. The hosted Action installs exact npm package versions, but npm installation
 still trusts the registry, the package publisher, and any lifecycle behavior allowed by that

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juror-ai",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juror-ai",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juror-ai",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Multi-model PR review that shows you the bill. Duplicate findings collapse into one, with optional agreement filtering.",
   "license": "MIT",
   "type": "module",

--- a/scripts/render-compatibility.mjs
+++ b/scripts/render-compatibility.mjs
@@ -26,6 +26,10 @@ const harnessMeta = {
     isolation: 'private runtime; `Read`, `Grep`, and `Glob` only',
     cost: 'usage-estimated; unknown without usage records',
   },
+  deepseek: {
+    isolation: 'private runtime; workspace-confined read/search tools; read-only sandbox',
+    cost: 'provider-usage estimated; unknown without usage events',
+  },
   opencode: {
     isolation: 'private HOME/XDG; mutating, shell, web, and task tools removed',
     cost: 'provider-reported per step; unknown on malformed output',

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,7 @@ const HARNESS_IDS: readonly HarnessId[] = [
   'codex',
   'grok-build',
   'kimi-code',
+  'deepseek',
   'opencode',
   'generic-openai',
 ];
@@ -42,6 +43,7 @@ const PROVIDER_ENV: Record<HarnessId, string> = {
   codex: 'OPENAI_API_KEY',
   'grok-build': 'XAI_API_KEY',
   'kimi-code': 'FIREWORKS_API_KEY',
+  deepseek: 'FIREWORKS_API_KEY',
   opencode: 'FIREWORKS_API_KEY',
   'generic-openai': 'OPENAI_API_KEY',
 };
@@ -67,6 +69,7 @@ const DEFAULT_SECRET: Record<HarnessId, string> = {
   codex: 'JUROR_OPENAI_API_KEY',
   'grok-build': 'JUROR_XAI_API_KEY',
   'kimi-code': 'JUROR_FIREWORKS_API_KEY',
+  deepseek: 'JUROR_FIREWORKS_API_KEY',
   opencode: 'JUROR_FIREWORKS_API_KEY',
   'generic-openai': 'JUROR_OPENAI_API_KEY',
 };
@@ -182,13 +185,14 @@ const BUILTIN_MODELS: Record<string, ModelConfig> = {
   },
   'deepseek-v4-flash-0731': {
     id: 'deepseek-v4-flash-0731',
-    harness: 'opencode',
+    harness: 'deepseek',
     enabled: true,
     secret: 'JUROR_FIREWORKS_API_KEY',
     label: 'DeepSeek V4 Flash',
-    harness_model: 'fireworks-ai/accounts/fireworks/models/deepseek-v4-flash-0731',
+    base_url: 'https://api.fireworks.ai/inference/v1',
+    harness_model: 'accounts/fireworks/models/deepseek-v4-flash-0731',
     pricing_key: 'accounts/fireworks/models/deepseek-v4-flash-0731',
-    args: { variant: 'high' },
+    args: { reasoning_effort: 'high' },
   },
 };
 
@@ -213,7 +217,9 @@ const PRESET_DEFINITIONS: Record<ReviewPreset, PresetDefinition> = {
     consensusModel: 'deepseek-v4-flash-0731',
     args: {
       'gpt-5.6-luna': { reasoning_effort: 'low' },
-      'deepseek-v4-flash-0731': { variant: 'low' },
+      // CodeWhale 0.9.7 normalizes Fireworks low/medium/high to the high wire tier.
+      // Keep the effective setting explicit instead of promising a tier the route ignores.
+      'deepseek-v4-flash-0731': { reasoning_effort: 'high' },
     },
   },
   balanced: {

--- a/src/harness/deepseek.ts
+++ b/src/harness/deepseek.ts
@@ -1,0 +1,328 @@
+/**
+ * DeepSeek-native adapter — CodeWhale `exec --output-format stream-json`.
+ *
+ * DeepSeek-TUI was renamed to CodeWhale in v0.9.0. The CLI remains the native
+ * DeepSeek agent runtime and, unlike a generic OpenAI loop, preserves DeepSeek's
+ * interleaved reasoning content across tool calls.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+
+import type {
+  CanonicalUsage,
+  Harness,
+  HarnessCommand,
+  HarnessIO,
+  HarnessLocation,
+  HarnessResult,
+  ModelReport,
+  RunContext,
+} from '../types.js';
+import { parseModelReport, readReportFile } from '../report.js';
+import { redact } from '../util/log.js';
+import { run, which } from '../util/proc.js';
+
+const MINIMUM_VERSION = [0, 9, 7] as const;
+const MAX_STDERR_DIAGNOSTICS = 20;
+const READ_ONLY_TOOLS = 'read,list_dir,grep_files,file_search';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function nonNegative(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function versionParts(version: string): number[] {
+  const match = /(?:^|\s)(\d+)\.(\d+)\.(\d+)(?:\D|$)/.exec(version);
+  return match ? match.slice(1, 4).map(Number) : [];
+}
+
+function versionBelowMinimum(version: string): boolean {
+  const parts = versionParts(version);
+  if (parts.length !== 3) return false;
+  for (let index = 0; index < MINIMUM_VERSION.length; index++) {
+    const actual = parts[index] ?? 0;
+    const minimum = MINIMUM_VERSION[index] ?? 0;
+    if (actual !== minimum) return actual < minimum;
+  }
+  return false;
+}
+
+function runtimeRoot(ctx: RunContext): string {
+  const key = createHash('sha256').update(resolve(ctx.scratchDir)).digest('hex').slice(0, 16);
+  return join(tmpdir(), 'juror-deepseek', key);
+}
+
+function physical(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+function readReportSafely(path: string): { report: ModelReport | null; problems: string[] } {
+  try {
+    return readReportFile(path);
+  } catch (error) {
+    return { report: null, problems: [error instanceof Error ? error.message : String(error)] };
+  }
+}
+
+function parseTextSafely(text: string): { report: ModelReport | null; problems: string[] } {
+  try {
+    return parseModelReport(text);
+  } catch (error) {
+    return { report: null, problems: [error instanceof Error ? error.message : String(error)] };
+  }
+}
+
+function parseJsonl(text: string): Record<string, unknown>[] {
+  const events: Record<string, unknown>[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.trim().startsWith('{')) continue;
+    try {
+      const value: unknown = JSON.parse(line);
+      if (isRecord(value)) events.push(value);
+    } catch {
+      // CodeWhale may emit a bounded diagnostic outside its JSON stream on startup.
+    }
+  }
+  return events;
+}
+
+function reasoningEffort(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const effort = value.trim().toLowerCase();
+  return ['off', 'low', 'medium', 'high', 'max'].includes(effort) ? effort : null;
+}
+
+export const deepseekHarness = {
+  id: 'deepseek',
+  label: 'DeepSeek',
+
+  async locate(env?: Record<string, string | undefined>): Promise<HarnessLocation> {
+    const binPath = await which('codewhale');
+    if (!binPath) {
+      throw new Error(
+        'codewhale not found on PATH — install it (npm i -g codewhale) or disable the DeepSeek model in .juror.yml',
+      );
+    }
+    const io = await run([binPath, '--version'], { timeoutMs: 15_000, ...(env ? { env } : {}) });
+    const version = (io.stdout.trim() || io.stderr.trim()).split('\n')[0]?.trim() ?? '';
+    const warnings: string[] = [];
+    if (io.exitCode !== 0) warnings.push(`codewhale --version exited ${io.exitCode}`);
+    if (!version) warnings.push('codewhale reported no version string');
+    else if (versionBelowMinimum(version)) {
+      warnings.push(`codewhale ${version} predates the tested 0.9.7 stream and isolation contract`);
+    }
+    return { binPath, version, warnings };
+  },
+
+  command(ctx: RunContext): HarnessCommand {
+    const root = runtimeRoot(ctx);
+    rmSync(root, { recursive: true, force: true });
+    const home = join(root, 'home');
+    const codewhaleHome = join(root, 'codewhale-home');
+    const emptySkills = join(root, 'skills');
+    const emptyTools = join(root, 'tools');
+    const workspace = join(root, 'workspace');
+    const mcpPath = join(root, 'mcp.json');
+    const configPath = join(root, 'config.toml');
+    mkdirSync(home, { recursive: true, mode: 0o700 });
+    mkdirSync(codewhaleHome, { recursive: true, mode: 0o700 });
+    mkdirSync(emptySkills, { recursive: true, mode: 0o700 });
+    mkdirSync(emptyTools, { recursive: true, mode: 0o700 });
+    mkdirSync(workspace, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      join(workspace, 'README.md'),
+      'Juror isolated review workspace. The reviewed source is an explicit read-only path.\n',
+      { encoding: 'utf8', mode: 0o600 },
+    );
+    writeFileSync(mcpPath, '{"mcpServers":{}}\n', { encoding: 'utf8', mode: 0o600 });
+    writeFileSync(
+      configPath,
+      [
+        'provider = "fireworks"',
+        'telemetry = false',
+        'allow_shell = false',
+        // `--auto` couples automatic approvals to host-wide trust in CodeWhale 0.9.7.
+        // Auto-review approves safe reads while leaving `trust_mode` false.
+        'approval_policy = "auto"',
+        'sandbox_mode = "read-only"',
+        'max_subagents = 1',
+        `skills_dir = ${JSON.stringify(emptySkills)}`,
+        `mcp_config_path = ${JSON.stringify(mcpPath)}`,
+        'instructions = []',
+        '',
+        '[skills]',
+        'scan_codewhale_only = true',
+        '',
+        '[tools]',
+        'always_load = ["list_dir", "file_search", "grep_files"]',
+        `plugin_dir = ${JSON.stringify(emptyTools)}`,
+        '',
+      ].join('\n'),
+      { encoding: 'utf8', mode: 0o600 },
+    );
+
+    // CodeWhale always discovers project instructions from its workspace, even with
+    // --no-project-config. Start in this trusted empty directory, then grant its path guard
+    // exactly the sealed checkout and Juror scratch. This also keeps trust_mode false, so an
+    // injected absolute path outside those two roots is refused by native file tools.
+    writeFileSync(
+      join(codewhaleHome, 'workspace-trust.json'),
+      `${JSON.stringify({
+        workspaces: {
+          [physical(workspace)]: [physical(ctx.repoDir), physical(ctx.scratchDir)].sort(),
+        },
+      })}\n`,
+      { encoding: 'utf8', mode: 0o600 },
+    );
+
+    const prompt =
+      `Read ${resolve(ctx.promptPath)} completely with the read tool and follow it exactly. ` +
+      `The reviewed repository is ${resolve(ctx.repoDir)}. ` +
+      'You have no write tools; return the requested strict JSON as your final answer.';
+    const argv = [
+      'codewhale',
+      '--config',
+      configPath,
+      '--no-project-config',
+      '--skip-onboarding',
+      '--provider',
+      'fireworks',
+      '--model',
+      ctx.model,
+      '-C',
+      physical(workspace),
+      'exec',
+      '--sandbox',
+      'read-only',
+      '--output-format',
+      'stream-json',
+      '--allowed-tools',
+      READ_ONLY_TOOLS,
+    ];
+    const effort = reasoningEffort(ctx.args['reasoning_effort']);
+    if (effort) argv.push('--reasoning-effort', effort);
+    if (ctx.maxTurns > 0) argv.push('--max-turns', String(ctx.maxTurns));
+    argv.push(prompt);
+
+    return {
+      argv,
+      env: {
+        ...ctx.env,
+        HOME: home,
+        CODEWHALE_HOME: codewhaleHome,
+        CODEWHALE_CONFIG_PATH: configPath,
+        CODEWHALE_ALLOW_SHELL: 'false',
+        DEEPSEEK_ALLOW_SHELL: 'false',
+        CODEWHALE_APPROVAL_POLICY: 'auto',
+        DEEPSEEK_APPROVAL_POLICY: 'auto',
+        CODEWHALE_SANDBOX_MODE: 'read-only',
+        DEEPSEEK_SANDBOX_MODE: 'read-only',
+        CODEWHALE_YOLO: 'false',
+        DEEPSEEK_YOLO: 'false',
+        CODEWHALE_TELEMETRY: '0',
+        CODEWHALE_TELEMETRY_ENDPOINT: '',
+        CODEWHALE_NO_UPDATE_CHECK: '1',
+        NO_UPDATE_NOTIFIER: '1',
+        ...(ctx.baseUrl ? { CODEWHALE_BASE_URL: ctx.baseUrl } : {}),
+      },
+      stdin: '',
+      cwd: physical(workspace),
+    };
+  },
+
+  parse(io: HarnessIO, ctx: RunContext): HarnessResult {
+    const events = parseJsonl(io.stdout);
+    const diagnostics = io.stderr
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .slice(0, MAX_STDERR_DIAGNOSTICS)
+      .map(redact);
+    const stderrLines = io.stderr.split(/\r?\n/).filter((line) => line.trim()).length;
+    if (stderrLines > MAX_STDERR_DIAGNOSTICS) {
+      diagnostics.push(`… ${stderrLines - MAX_STDERR_DIAGNOSTICS} more stderr line(s)`);
+    }
+    if (events.length === 0) diagnostics.push('codewhale emitted no stream-json events');
+
+    const text = events
+      .filter((event) => event['type'] === 'content' && typeof event['content'] === 'string')
+      .map((event) => String(event['content']))
+      .join('');
+    const usage: CanonicalUsage = { uncachedIn: 0, cacheRead: 0, cacheWrite: 0, out: 0 };
+    let turns = 0;
+    let terminalStatus = '';
+    let resolvedModel: string | undefined;
+    let sawError = false;
+
+    for (const event of events) {
+      if (event['type'] === 'error') {
+        sawError = true;
+        if (typeof event['error'] === 'string') diagnostics.push(redact(event['error']));
+      }
+      if (event['type'] === 'metadata' && isRecord(event['meta'])) {
+        const meta = event['meta'];
+        terminalStatus = typeof meta['status'] === 'string' ? meta['status'] : terminalStatus;
+        resolvedModel = typeof meta['model'] === 'string' ? meta['model'] : resolvedModel;
+      }
+      if (event['type'] !== 'turn_usage') continue;
+      const input = nonNegative(event['input_tokens']);
+      const output = nonNegative(event['output_tokens']);
+      if (input === null || output === null) {
+        diagnostics.push('ignored malformed CodeWhale turn_usage event');
+        continue;
+      }
+      const cacheRead = nonNegative(event['prompt_cache_hit_tokens']) ?? 0;
+      const cacheWrite = nonNegative(event['prompt_cache_write_tokens']) ?? 0;
+      const cacheMiss = nonNegative(event['prompt_cache_miss_tokens']);
+      usage.uncachedIn += cacheMiss ?? Math.max(0, input - cacheRead);
+      usage.cacheRead += cacheRead;
+      usage.cacheWrite += cacheWrite;
+      usage.out += output;
+      turns += 1;
+    }
+
+    let report: ModelReport | null = null;
+    if (basename(ctx.findingsPath) === 'findings.json') {
+      const file = readReportSafely(ctx.findingsPath);
+      report = file.report;
+      diagnostics.push(...file.problems);
+      if (!report && text.trim()) {
+        const parsed = parseTextSafely(text);
+        diagnostics.push(...parsed.problems);
+        if (parsed.report) {
+          report = parsed.report;
+          diagnostics.push('findings file missing — recovered the report from the final answer');
+        }
+      }
+    }
+
+    return {
+      report,
+      usage: turns > 0 ? usage : null,
+      reportedCostUsd: null,
+      ...(resolvedModel ? { resolvedModel } : {}),
+      ...(turns > 0 ? { usageSource: 'provider' as const } : {}),
+      turns,
+      truncated:
+        io.timedOut ||
+        io.exitCode !== 0 ||
+        (terminalStatus === '' ? sawError : terminalStatus !== 'completed'),
+      rawText: text,
+      diagnostics,
+    };
+  },
+
+  cleanup(ctx: RunContext): void {
+    rmSync(runtimeRoot(ctx), { recursive: true, force: true });
+  },
+} satisfies Harness;

--- a/src/harness/registry.ts
+++ b/src/harness/registry.ts
@@ -9,6 +9,7 @@
 import type { Harness, HarnessId } from '../types.js';
 import { claudeHarness } from './claude.js';
 import { codexHarness } from './codex.js';
+import { deepseekHarness } from './deepseek.js';
 import { genericOpenAIHarness } from './generic-openai.js';
 import { grokHarness } from './grok.js';
 import { kimiHarness } from './kimi.js';
@@ -17,6 +18,7 @@ import { opencodeHarness } from './opencode.js';
 export const HARNESSES: Record<HarnessId, Harness> = {
   'claude-code': claudeHarness,
   codex: codexHarness,
+  deepseek: deepseekHarness,
   'grok-build': grokHarness,
   'kimi-code': kimiHarness,
   opencode: opencodeHarness,

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,6 +174,7 @@ export type HarnessId =
   | 'codex'
   | 'grok-build'
   | 'kimi-code'
+  | 'deepseek'
   | 'opencode'
   | 'generic-openai';
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -46,14 +46,12 @@ describe('defaultConfig', () => {
     expect(c.models[0]?.harness).toBe('codex');
     expect(c.models[0]?.secret).toBe('JUROR_OPENAI_API_KEY');
     expect(c.models[0]?.args?.['reasoning_effort']).toBe('low');
-    expect(c.models[1]?.harness).toBe('opencode');
+    expect(c.models[1]?.harness).toBe('deepseek');
     expect(c.models[1]?.secret).toBe('JUROR_FIREWORKS_API_KEY');
-    expect(c.models[1]?.harness_model).toBe(
-      'fireworks-ai/accounts/fireworks/models/deepseek-v4-flash-0731',
-    );
+    expect(c.models[1]?.harness_model).toBe('accounts/fireworks/models/deepseek-v4-flash-0731');
     expect(c.models[1]?.pricing_key).toBe('accounts/fireworks/models/deepseek-v4-flash-0731');
-    // The fast preset deliberately lowers both models' thinking settings.
-    expect(c.models[1]?.args?.['variant']).toBe('low');
+    // CodeWhale 0.9.7 maps every non-max Fireworks reasoning tier to high.
+    expect(c.models[1]?.args?.['reasoning_effort']).toBe('high');
     expect(c.consensus.verify_model).toBe('deepseek-v4-flash-0731');
     expect(c.consensus.referee_model).toBe('deepseek-v4-flash-0731');
     // Kept well clear of the jury's slowest legitimate run: Luna was measured at 750–900s
@@ -101,7 +99,7 @@ describe('defaultConfig', () => {
     expect(starter.models.every((model) => model.args?.['usage_cost'] === 'usd')).toBe(true);
     expect(starter.consensus.referee_model).toBe('openrouter-deepseek-v4-flash');
     expect(fast.models.map((m) => m.id)).toEqual(['gpt-5.6-luna', 'deepseek-v4-flash-0731']);
-    expect(fast.models.map((m) => m.args?.['reasoning_effort'] ?? m.args?.['variant'])).toEqual(['low', 'low']);
+    expect(fast.models.map((m) => m.args?.['reasoning_effort'] ?? m.args?.['variant'])).toEqual(['low', 'high']);
     expect(fast.consensus.referee_model).toBe('deepseek-v4-flash-0731');
     // No longer the default, so this is the only place its membership is pinned.
     expect(balanced.models.map((m) => m.id)).toEqual(['gpt-5.6-terra', 'grok-4.5', 'kimi-k3']);
@@ -161,9 +159,10 @@ describe('provider credentials', () => {
     expect(providerEnvFor('codex')).toBe('OPENAI_API_KEY');
     expect(providerEnvFor('grok-build')).toBe('XAI_API_KEY');
     expect(providerEnvFor('kimi-code')).toBe('FIREWORKS_API_KEY');
+    expect(providerEnvFor('deepseek')).toBe('FIREWORKS_API_KEY');
     expect(providerEnvFor('opencode')).toBe('FIREWORKS_API_KEY');
     expect(providerEnvFor('generic-openai')).toBe('OPENAI_API_KEY');
-    for (const harness of ['claude-code', 'codex', 'grok-build', 'kimi-code', 'opencode', 'generic-openai'] as const) {
+    for (const harness of ['claude-code', 'codex', 'grok-build', 'kimi-code', 'deepseek', 'opencode', 'generic-openai'] as const) {
       expect(providerEnvFor(harness).startsWith('JUROR_')).toBe(false);
     }
   });

--- a/test/deepseek.test.ts
+++ b/test/deepseek.test.ts
@@ -1,0 +1,250 @@
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  realpathSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { deepseekHarness } from '../src/harness/deepseek.js';
+import type { HarnessIO, RunContext } from '../src/types.js';
+
+const cleanup: string[] = [];
+
+afterEach(() => {
+  for (const path of cleanup.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+const REPORT = {
+  merge_confidence: 4,
+  confidence_reason: 'One concrete defect.',
+  summary: 'Reviews the changed path.',
+  highlights: [],
+  file_overviews: [],
+  async_contracts: [],
+  sequence_diagram: null,
+  findings: [
+    {
+      path: 'src/a.ts',
+      line: 12,
+      end_line: null,
+      severity: 'P1',
+      title: 'Guard is bypassed',
+      body: 'The new branch skips validation.',
+      category: 'correctness',
+      confidence: 0.9,
+      convention: null,
+    },
+  ],
+};
+
+function context(maxTurns = 0): RunContext {
+  const root = mkdtempSync(join(tmpdir(), 'juror-deepseek-test-'));
+  cleanup.push(root);
+  const repoDir = join(root, 'repo');
+  const scratchDir = join(root, 'scratch');
+  mkdirSync(repoDir);
+  mkdirSync(scratchDir);
+  return {
+    repoDir,
+    scratchDir,
+    findingsPath: join(scratchDir, 'findings.json'),
+    promptPath: join(scratchDir, 'prompt.md'),
+    prompt: 'review this repository',
+    model: 'accounts/fireworks/models/deepseek-v4-flash-0731',
+    baseUrl: 'https://api.fireworks.ai/inference/v1',
+    args: { reasoning_effort: 'low' },
+    env: { FIREWORKS_API_KEY: 'test-only' },
+    timeoutMs: 60_000,
+    budgetUsd: null,
+    maxTurns,
+  };
+}
+
+function io(stdout: string, over: Partial<HarnessIO> = {}): HarnessIO {
+  return {
+    stdout,
+    stderr: '',
+    exitCode: 0,
+    signal: null,
+    durationMs: 100,
+    timedOut: false,
+    ...over,
+  };
+}
+
+describe('DeepSeek command isolation', () => {
+  it('pins and installs CodeWhale in the GitHub Action', () => {
+    const action = readFileSync(join(process.cwd(), 'action.yml'), 'utf8');
+    expect(action).toContain("default: 'codewhale@0.9.7'");
+    expect(action).toContain('DEEPSEEK_SPEC: ${{ inputs.deepseek-version }}');
+    expect(action).toContain('install_harness codewhale "$DEEPSEEK_SPEC"');
+  });
+
+  it('uses CodeWhale with a private runtime and a read-only tool surface', () => {
+    const ctx = context();
+    Object.assign(ctx.env, {
+      CODEWHALE_ALLOW_SHELL: 'true',
+      DEEPSEEK_ALLOW_SHELL: 'true',
+      CODEWHALE_APPROVAL_POLICY: 'never',
+      DEEPSEEK_APPROVAL_POLICY: 'never',
+      CODEWHALE_SANDBOX_MODE: 'danger-full-access',
+      DEEPSEEK_SANDBOX_MODE: 'danger-full-access',
+      CODEWHALE_YOLO: 'true',
+      DEEPSEEK_YOLO: 'true',
+    });
+    const command = deepseekHarness.command(ctx);
+    const configPath = command.argv[command.argv.indexOf('--config') + 1] as string;
+    const runtimeRoot = dirname(command.env['HOME'] as string);
+    const trustPath = join(command.env['CODEWHALE_HOME'] as string, 'workspace-trust.json');
+    cleanup.push(runtimeRoot);
+
+    expect(command.argv[0]).toBe('codewhale');
+    expect(command.argv).toContain('--no-project-config');
+    expect(command.argv).not.toContain('--auto');
+    expect(command.argv[command.argv.indexOf('--provider') + 1]).toBe('fireworks');
+    expect(command.argv[command.argv.indexOf('--model') + 1]).toBe(ctx.model);
+    expect(command.argv[command.argv.indexOf('--sandbox') + 1]).toBe('read-only');
+    expect(command.argv[command.argv.indexOf('--allowed-tools') + 1]).toBe(
+      'read,list_dir,grep_files,file_search',
+    );
+    expect(command.argv).not.toContain(ctx.prompt);
+    expect(command.argv.at(-1)).toContain(ctx.promptPath);
+    expect(command.argv.at(-1)).toContain(ctx.repoDir);
+    expect(command.cwd).not.toBe(ctx.repoDir);
+    expect(command.argv[command.argv.indexOf('-C') + 1]).toBe(command.cwd);
+    expect(readFileSync(join(command.cwd, 'README.md'), 'utf8')).toContain(
+      'Juror isolated review workspace',
+    );
+    expect(command.stdin).toBe('');
+    expect(command.env['FIREWORKS_API_KEY']).toBe('test-only');
+    expect(command.env['CODEWHALE_BASE_URL']).toBe(ctx.baseUrl);
+    expect(command.env['CODEWHALE_TELEMETRY']).toBe('0');
+    expect(command.env['CODEWHALE_NO_UPDATE_CHECK']).toBe('1');
+    expect(command.env['CODEWHALE_ALLOW_SHELL']).toBe('false');
+    expect(command.env['DEEPSEEK_ALLOW_SHELL']).toBe('false');
+    expect(command.env['CODEWHALE_APPROVAL_POLICY']).toBe('auto');
+    expect(command.env['DEEPSEEK_APPROVAL_POLICY']).toBe('auto');
+    expect(command.env['CODEWHALE_SANDBOX_MODE']).toBe('read-only');
+    expect(command.env['DEEPSEEK_SANDBOX_MODE']).toBe('read-only');
+    expect(command.env['CODEWHALE_YOLO']).toBe('false');
+    expect(command.env['DEEPSEEK_YOLO']).toBe('false');
+    expect(command.env['CODEWHALE_HOME']).not.toContain(ctx.repoDir);
+    expect(statSync(runtimeRoot).mode & 0o077).toBe(0);
+
+    const trust = JSON.parse(readFileSync(trustPath, 'utf8')) as {
+      workspaces: Record<string, string[]>;
+    };
+    expect(trust.workspaces[command.cwd]).toEqual(
+      expect.arrayContaining([realpathSync(ctx.repoDir), realpathSync(ctx.scratchDir)]),
+    );
+
+    const config = readFileSync(configPath, 'utf8');
+    expect(config).toContain('provider = "fireworks"');
+    expect(config).toContain('telemetry = false');
+    expect(config).toContain('allow_shell = false');
+    expect(config).toContain('approval_policy = "auto"');
+    expect(config).toContain('sandbox_mode = "read-only"');
+    expect(config).toContain('scan_codewhale_only = true');
+    expect(config).toContain('always_load = ["list_dir", "file_search", "grep_files"]');
+
+    deepseekHarness.cleanup?.(ctx);
+    expect(existsSync(runtimeRoot)).toBe(false);
+  });
+
+  it('passes reasoning and an explicit positive turn cap', () => {
+    const ctx = context(75);
+    const command = deepseekHarness.command(ctx);
+    cleanup.push(dirname(command.env['HOME'] as string));
+    expect(command.argv[command.argv.indexOf('--reasoning-effort') + 1]).toBe('low');
+    expect(command.argv[command.argv.indexOf('--max-turns') + 1]).toBe('75');
+  });
+
+  it('omits unsafe reasoning values and the unlimited turn flag', () => {
+    const ctx = context();
+    ctx.args.reasoning_effort = 'high; echo nope';
+    const command = deepseekHarness.command(ctx);
+    cleanup.push(dirname(command.env['HOME'] as string));
+    expect(command.argv).not.toContain('--reasoning-effort');
+    expect(command.argv).not.toContain('--max-turns');
+  });
+});
+
+describe('DeepSeek stream-json parsing', () => {
+  it('recovers the report and sums provider usage across tool rounds', () => {
+    const ctx = context();
+    const stdout = [
+      { type: 'content', content: JSON.stringify(REPORT).slice(0, 80) },
+      {
+        type: 'turn_usage',
+        turn: 1,
+        input_tokens: 120,
+        output_tokens: 20,
+        prompt_cache_hit_tokens: 80,
+        prompt_cache_miss_tokens: 40,
+        prompt_cache_write_tokens: 3,
+      },
+      { type: 'content', content: JSON.stringify(REPORT).slice(80) },
+      {
+        type: 'turn_usage',
+        turn: 2,
+        input_tokens: 150,
+        output_tokens: 25,
+        prompt_cache_hit_tokens: 90,
+        prompt_cache_miss_tokens: 60,
+      },
+      { type: 'metadata', meta: { status: 'completed', model: ctx.model } },
+      { type: 'done' },
+    ].map((event) => JSON.stringify(event)).join('\n');
+
+    const result = deepseekHarness.parse(io(stdout), ctx);
+    expect(result.report).toEqual(REPORT);
+    expect(result.rawText).toBe(JSON.stringify(REPORT));
+    expect(result.usage).toEqual({ uncachedIn: 100, cacheRead: 170, cacheWrite: 3, out: 45 });
+    expect(result.turns).toBe(2);
+    expect(result.usageSource).toBe('provider');
+    expect(result.resolvedModel).toBe(ctx.model);
+    expect(result.reportedCostUsd).toBeNull();
+    expect(result.truncated).toBe(false);
+  });
+
+  it('prefers an exact findings file when the task is a model review', () => {
+    const ctx = context();
+    writeFileSync(ctx.findingsPath, `${JSON.stringify(REPORT)}\n`, 'utf8');
+    const result = deepseekHarness.parse(io('{"type":"content","content":"not json"}\n'), ctx);
+    expect(result.report).toEqual(REPORT);
+  });
+
+  it('treats completed terminal metadata as authoritative over a recoverable error event', () => {
+    const ctx = context();
+    const stdout = [
+      { type: 'error', error: 'transient stream warning' },
+      { type: 'content', content: JSON.stringify(REPORT) },
+      { type: 'metadata', meta: { status: 'completed' } },
+    ].map((event) => JSON.stringify(event)).join('\n');
+    const result = deepseekHarness.parse(io(stdout), ctx);
+    expect(result.truncated).toBe(false);
+    expect(result.diagnostics).toContain('transient stream warning');
+  });
+
+  it('marks process and terminal failures partial while retaining diagnostics', () => {
+    const ctx = context();
+    const stdout = [
+      { type: 'error', error: 'provider unavailable' },
+      { type: 'metadata', meta: { status: 'failed' } },
+    ].map((event) => JSON.stringify(event)).join('\n');
+    const result = deepseekHarness.parse(
+      io(stdout, { exitCode: 1, stderr: 'request failed\n' }),
+      ctx,
+    );
+    expect(result.truncated).toBe(true);
+    expect(result.diagnostics).toContain('provider unavailable');
+    expect(result.diagnostics).toContain('request failed');
+  });
+});


### PR DESCRIPTION
## TL;DR

Routes the built-in DeepSeek model through the native CodeWhale harness instead of opencode, with an isolated read-only tool runtime and provider usage accounting. Bumps the release version to 1.4.0.

## Summary

- add the CodeWhale 0.9.7 harness and route DeepSeek V4 Flash through it
- enforce a clean workspace/trust boundary, read/search-only tools, and hardened environment floors
- parse stream receipts and provider usage; update Action installation, compatibility docs, and release version

## Review focus

- CodeWhale 0.9.7 command and isolation contract
- stream usage normalization and the Fireworks route
- no database migrations

## Test plan

- [x] `npm test` — 400 tests
- [x] build and typecheck
- [x] compatibility and secure-reference checks
- [x] npm package dry run
- [x] local CodeWhale mock-provider boundary smoke
- [x] iterative local Codex review; all verified findings resolved

Closes #60