### PR TITLE
fix(release): publish the packed tarball, not a git shorthand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,9 @@ jobs:
 
       # npm trusted publishing exchanges the job's OIDC identity. No long-lived npm token
       # is present, and this exact, already-attested tarball is what reaches the registry.
+      # The path stays explicitly relative: npm reads a bare `dir/file` argument as the
+      # `owner/repo` GitHub shorthand and would resolve the release off a git remote.
       - name: Publish the attested npm package
         env:
           NPM_TARBALL: ${{ steps.artifacts.outputs.npm-tarball }}
-        run: npm publish "$NPM_TARBALL" --provenance --access public
+        run: npm publish "./$NPM_TARBALL" --provenance --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juror-ai",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juror-ai",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juror-ai",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Multi-model PR review that shows you the bill. Duplicate findings collapse into one, with optional agreement filtering.",
   "license": "MIT",
   "type": "module",

--- a/test/supply-chain.test.ts
+++ b/test/supply-chain.test.ts
@@ -78,7 +78,20 @@ describe('supply-chain policy', () => {
     expect(workflow).toContain('npm pack');
     expect(workflow).toContain('npm sbom');
     expect(workflow).toContain('sbom-path:');
-    expect(workflow).toContain('npm publish "$NPM_TARBALL" --provenance --access public');
+    expect(workflow).toContain('--provenance --access public');
+  });
+
+  it('hands npm a local tarball path instead of a GitHub owner/repo shorthand', () => {
+    const workflow = parse(read('.github/workflows/release.yml')) as {
+      jobs: { publish: { steps: { run?: string }[] } };
+    };
+    const publish = workflow.jobs.publish.steps.filter((step) => step.run?.includes('npm publish'));
+
+    // `npm publish release/juror-ai-1.4.0.tgz` resolved as `github:release/juror-ai-1.4.0.tgz`
+    // and failed the v1.4.0 release. Only an explicitly relative or absolute path is read as
+    // the packed file rather than as an `owner/repo` git spec.
+    expect(publish).toHaveLength(1);
+    expect(publish[0]?.run).toMatch(/npm publish "(\.\/|\/)/);
   });
 
   it('rejects release identity mismatches before building or publishing', () => {


### PR DESCRIPTION
## What broke

The v1.4.0 release workflow ([run 31722616887](https://github.com/Juror-AI/juror/actions/runs/31722616887)) failed on its last step:

```
npm error code EALLOWGIT
npm error Fetching packages of type "git" have been disabled
npm error Refusing to fetch "github:release/juror-ai-1.4.0.tgz"
```

`npm publish "$NPM_TARBALL"` received `release/juror-ai-1.4.0.tgz`. A bare `dir/file` argument matches npm's `owner/repo` GitHub shorthand, so npm resolved it as a git spec instead of the packed tarball on disk.

Every earlier step succeeded, which is why `v1.4.0` exists as a tag and a GitHub release with attested assets, but `juror-ai` on npm is still `1.3.3`.

## Fix

Pass the path as explicitly relative (`./$NPM_TARBALL`). Only `./`, `../`, `/`, or `~/` prefixes make npm read the argument as a file.

Reproduced and verified against the real packed artifact:

```
$ npm publish "release/juror-ai-1.4.1.tgz" --dry-run
npm error command git ... ls-remote ssh://git@github.com/release/juror-ai-1.4.1.tgz.git
npm error ERROR: Repository not found.

$ npm publish "./release/juror-ai-1.4.1.tgz" --dry-run
npm notice name: juror-ai
npm notice version: 1.4.1
npm notice package size: 427.2 kB
```

## Regression guard

`test/supply-chain.test.ts` previously asserted the exact old command string, so it passed on the broken form. It now parses the workflow and rejects any `npm publish` step whose argument is not explicitly relative or absolute. Confirmed the guard fails when the old form is restored.

## Version

Bumped to **1.4.1**. `docs/releasing.md` says not to reuse a failed release tag for different source, and `scripts/verify-release.mjs` requires the tag to resolve to the checked-out commit — so v1.4.0 stays pinned to its own source and this ships as a new tag.

## Validation

`npm run typecheck`, `npm test` (401 passed, 35 files), `npm run check:secure-refs`, `npm run build` — all green locally.