### PR TITLE
fix(qa): preserve empty evidence payloads

### DIFF
--- a/docs/2026-08-18-post-merge-qa-quickstart.md
+++ b/docs/2026-08-18-post-merge-qa-quickstart.md
@@ -456,11 +456,13 @@ Useful evidence files include:
 - `agent-events.ndjson` and `agent-result.json`: redacted agent protocol diagnostics.
 
 In GitHub Actions, Juror first validates the completed `payload-status.json` sentinel and strict
-`report.json`, then reconstructs an immutable payload in a fresh staging directory from only the
-report artifact ledger. Every entry must be an allowlisted regular file whose SHA-256 matches the
-report and whose exact bytes contain none of the configured secrets; an unlisted file, symlink,
-missing entry, hash mismatch, or surviving canary stages nothing and fails closed. The staged
-payload contains browser evidence but no semantic report or completion sentinel. Juror uploads it,
+`report.json`, then reconstructs an immutable payload in a fresh staging directory from the report
+artifact ledger. Every entry must be an allowlisted regular file whose SHA-256 matches the report
+and whose exact bytes contain none of the configured secrets; an unlisted file, symlink, missing
+entry, hash mismatch, or surviving canary stages nothing and fails closed. When the ledger is empty,
+the stager adds a static Action-owned `payload-empty.json` sentinel so the immutable payload remains
+uploadable without adding semantic evidence. The staged payload contains browser evidence or that
+static sentinel, but no semantic report or completion sentinel. Juror uploads it,
 then finalizes the result using that exact payload URL, publishes an
 explicitly non-final sticky, and uploads `report.json` plus `summary.md` as a separate immutable
 result artifact. Only after that succeeds does the sticky transition to the final verdict; if the

--- a/docs/post-merge-agentic-e2e-qa-plan.md
+++ b/docs/post-merge-agentic-e2e-qa-plan.md
@@ -408,10 +408,11 @@ Evidence policy:
 - Include the final plan and machine-readable result for every run.
 - Do not collect authentication video, passwords, cookies, storage state, request/response bodies by default, authorization headers, private agent homes, or unrestricted scratch directories.
 - Upload only files matching fixed controller-owned artifact manifests. Before upload, require a
-  strict completed report and payload sentinel, rebuild a fresh staging directory solely from the
-  report ledger, and require every entry to be an allowlisted regular file with the reported
-  SHA-256 and no configured secret bytes. Any missing, unlisted, symlinked, mismatched, or canary-
-  bearing entry stages nothing and fails closed. Upload browser evidence as
+  strict completed report and payload sentinel, rebuild a fresh staging directory from the report
+  ledger, and require every entry to be an allowlisted regular file with the reported SHA-256 and
+  no configured secret bytes. If the ledger is empty, add only a static controller-owned upload
+  sentinel so pre-browser results remain deliverable. Any missing, unlisted, symlinked, mismatched,
+  or canary-bearing entry stages nothing and fails closed. Upload browser evidence as
   an immutable payload without `report.json`, `summary.md`, or the completion sentinel; finalize and publish against the
   payload's exact URL, publish a visibly non-final sticky, then upload the finalized report and
   summary as a separate immutable result. Transition the sticky to its final verdict only after the

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -137,8 +137,9 @@ CI runs the full test suite, a provider-key shape scan, and `npm run check:secur
 containment tests verify exact plan/runtime assertion binding, identical sealed acknowledgements,
 hidden `qa_status` outcomes, mandatory sensitive-state retries, the credential-scrubbed Chromium
 environment, and configured-secret scans after the final report and summary exist. Release artifacts
-are rebuilt in an empty staging directory from strict report-ledger entries only; each regular file
-must match its reported SHA-256 and pass an exact-byte secret scan. Semantic scans cover the actual
+are rebuilt in an empty staging directory from strict report-ledger entries; an empty ledger produces
+only a static controller-owned upload sentinel. Each ledger file must match its reported SHA-256 and
+pass an exact-byte secret scan. Semantic scans cover the actual
 destination bytes, including any emitted trailing newline, and the secret bundle is forwarded by
 name only to the trusted finalizer and publisher containers that need it. Release artifacts can be checked
 with the commands in [the release guide](releasing.md). Report boundary escapes,

--- a/qa/action.yml
+++ b/qa/action.yml
@@ -643,8 +643,9 @@ runs:
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: juror-qa-evidence-pr-${{ steps.runtime.outputs.pr-number }}-${{ github.run_id }}-${{ github.run_attempt }}
-        # This directory contains only strict, hash-verified report-ledger entries. The completion
-        # marker, semantic report, and summary are validated but deliberately excluded.
+        # This directory contains strict, hash-verified report-ledger entries, or a static
+        # Action-owned sentinel when that ledger is empty. The completion marker, semantic report,
+        # and summary are validated but deliberately excluded.
         path: ${{ steps.stage_evidence.outputs.path }}
         if-no-files-found: error
         retention-days: ${{ steps.qa.outputs.retention-days || 14 }}

--- a/qa/stage-evidence.mjs
+++ b/qa/stage-evidence.mjs
@@ -13,6 +13,7 @@ import {
   realpath,
   rename,
   rm,
+  writeFile,
 } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -21,6 +22,8 @@ import { TextDecoder } from 'node:util';
 import { isQaRunResult } from '../src/qa/result-validator.js';
 
 const MAX_CONTROL_BYTES = 16 * 1024 * 1024;
+const EMPTY_PAYLOAD_FILE = 'payload-empty.json';
+const EMPTY_PAYLOAD_BODY = '{"schema_version":1,"artifacts":[]}\n';
 const ROOT_EVIDENCE_KINDS = new Map([
   ['plan.json', 'plan'],
   ['agent-events.ndjson', 'ledger'],
@@ -371,9 +374,21 @@ export async function stageEvidencePayload(evidenceDirectory, stagingDirectory, 
       await copyFile(source, destination, fsConstants.COPYFILE_EXCL);
       await verifyArtifactFile(destination, artifact.sha256, canaries, temporary);
     }
+    const stagedFiles = artifacts.map((artifact) => artifact.path);
+    if (stagedFiles.length === 0) {
+      // upload-artifact treats an empty directory as an error. Keep the payload
+      // deliverable without promoting this static, Action-owned sentinel into
+      // the semantic artifact ledger.
+      await writeFile(path.join(temporary, EMPTY_PAYLOAD_FILE), EMPTY_PAYLOAD_BODY, {
+        encoding: 'utf8',
+        flag: 'wx',
+        mode: 0o600,
+      });
+      stagedFiles.push(EMPTY_PAYLOAD_FILE);
+    }
     await rename(temporary, staging);
     temporary = null;
-    return { directory: staging, files: artifacts.map((artifact) => artifact.path) };
+    return { directory: staging, files: stagedFiles };
   } catch (error) {
     await rm(staging, { recursive: true, force: true });
     if (error instanceof StageEvidenceError) throw error;

--- a/test/qa-stage-evidence.test.ts
+++ b/test/qa-stage-evidence.test.ts
@@ -234,6 +234,32 @@ describe('stageEvidencePayload', () => {
     }
   });
 
+  it('stages a static upload sentinel for a completed pre-browser result without artifacts', async () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'juror-stage-evidence-empty-'));
+    try {
+      const evidence = join(scratch, 'evidence');
+      const staged = join(scratch, 'staged');
+      mkdirSync(evidence);
+      const blocked = result([]);
+      blocked.outcome = 'blocked';
+      blocked.conclusion = 'failure';
+      blocked.target = null;
+      blocked.plan = null;
+      blocked.attempts = [];
+      complete(evidence, blocked);
+
+      await expect(stageEvidencePayload(evidence, staged)).resolves.toMatchObject({
+        files: ['payload-empty.json'],
+      });
+      expect(files(staged)).toEqual(['payload-empty.json']);
+      expect(readFileSync(join(staged, 'payload-empty.json'), 'utf8')).toBe(
+        '{"schema_version":1,"artifacts":[]}\n',
+      );
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
   it('rejects a partial plan without a completed marker and report, leaving no staged payload', async () => {
     const scratch = mkdtempSync(join(tmpdir(), 'juror-stage-evidence-partial-'));
     try {


### PR DESCRIPTION
## TL;DR

Keep legitimate pre-browser QA outcomes from being rewritten to `infrastructure_error` when their validated artifact ledger is empty.

## Summary

- stage a fixed Action-owned `payload-empty.json` sentinel only when the validated report ledger has no artifacts
- keep the sentinel outside the semantic artifact ledger while preserving fail-closed `upload-artifact` behavior
- cover a targetless pre-browser `blocked` result with an empty ledger
- document the empty-payload boundary in the action, quickstart, implementation plan, and threat model

The targetless `no_testable_surface` validator ordering and regression test from the review are already present in merged PR #67; this follow-up fixes the remaining upload path.

## Review focus

- `qa/stage-evidence.mjs`: empty-ledger staging and sentinel ownership
- `test/qa-stage-evidence.test.ts`: pre-browser empty-artifact regression

## Test plan

- [x] `npx vitest run test/qa-result-validator.test.ts test/qa-stage-evidence.test.ts test/supply-chain.test.ts`
- [x] `npm test` (52 files, 805 tests)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run check:secure-refs`
- [x] `git diff --check`