### PR TITLE
chore: release v1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juror-ai",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juror-ai",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juror-ai",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Multi-model PR review that shows you the bill. Duplicate findings collapse into one, with optional agreement filtering.",
   "license": "MIT",
   "type": "module",

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -20,6 +20,9 @@ import {
 import type { RunOptions } from '../src/util/proc.js';
 
 const dirs: string[] = [];
+const packageVersion = (JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as { version: string }).version;
 
 function tempRepo(): string {
   const dir = mkdtempSync(join(tmpdir(), 'juror-init-'));
@@ -630,7 +633,7 @@ describe('juror init CLI', () => {
     expect(output).toContain('Workflow: .github/workflows/juror.yml created');
     expect(output).not.toContain('test-only-value');
     const workflow = readFileSync(join(repo, '.github/workflows/juror.yml'), 'utf8');
-    expect(workflow).toContain(`juror-ai/juror@${'b'.repeat(40)} # v1.4.1`);
+    expect(workflow).toContain(`juror-ai/juror@${'b'.repeat(40)} # v${packageVersion}`);
   });
 
   it('does not create a workflow when requested secret setup cannot start', () => {


### PR DESCRIPTION
## TL;DR

Bump the Juror package identity from v1.4.1 to v1.4.2 so the merged hardened QA runtime can be released through the trusted publishing workflows. Make the CLI integration assertion derive the current package version so future releases remain testable.

## Summary

- update `package.json` to `1.4.2`
- update both root package identities in `package-lock.json` to `1.4.2`
- replace one hardcoded `v1.4.1` integration expectation with the package version under test

## Review focus

- package and lockfile identities must agree on `1.4.2`
- the test-only change must preserve the generated workflow assertion while removing release-specific hardcoding
- the release tag will be created only after this PR is merged with green CI

## Test plan

- [x] package and lockfile identities agree on `1.4.2`
- [x] `test/init.test.ts`: 28/28 pass
- [x] typecheck passes
- [x] immutable Action reference check passes
- [x] GitHub CI passes