### PR TITLE
fix(qa): bypass broken DinD proxy DNS

### DIFF
--- a/qa/action.yml
+++ b/qa/action.yml
@@ -469,11 +469,8 @@ runs:
           --env GITHUB_SERVER_URL
           --env GITHUB_REPOSITORY
           --env GITHUB_RUN_ID
-          --env HTTP_PROXY=http://juror-qa-proxy:8080
-          --env HTTPS_PROXY=http://juror-qa-proxy:8080
           --env NODE_OPTIONS=--use-env-proxy
           --env NODE_USE_ENV_PROXY=1
-          --env JUROR_QA_BROWSER_PROXY=http://juror-qa-proxy:8080
         )
 
         SUFFIX="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}-$$"
@@ -529,7 +526,21 @@ runs:
           --entrypoint node \
           "$EXACT_IMAGE" \
           /opt/juror/qa/egress-proxy.mjs >/dev/null
-        docker network connect --gw-priority -1 --alias juror-qa-proxy "$INTERNAL_NETWORK" "$PROXY_NAME"
+        docker network connect --gw-priority -1 "$INTERNAL_NETWORK" "$PROXY_NAME"
+        # Docker-in-Docker runners can route this private bridge while their embedded DNS
+        # fails to resolve container names and aliases. Read the already-created endpoint
+        # address from Docker itself, validate that it is private, and avoid that DNS path.
+        PROXY_URL="$(
+          docker inspect \
+            --format "{{(index .NetworkSettings.Networks \"$INTERNAL_NETWORK\").IPAddress}}" \
+            "$PROXY_NAME" |
+            node "$GITHUB_ACTION_PATH/proxy-url.mjs"
+        )"
+        ENVIRONMENT+=(
+          --env "HTTP_PROXY=$PROXY_URL"
+          --env "HTTPS_PROXY=$PROXY_URL"
+          --env "JUROR_QA_BROWSER_PROXY=$PROXY_URL"
+        )
         for _ in $(seq 1 40); do
           if docker logs "$PROXY_NAME" 2>&1 | grep -q 'juror-qa-egress-proxy ready'; then break; fi
           sleep 0.25

--- a/qa/proxy-url.mjs
+++ b/qa/proxy-url.mjs
@@ -3,19 +3,23 @@
 import { readFileSync } from 'node:fs';
 import net from 'node:net';
 
-function privateIpv4(address) {
+function dockerInternalIpv4(address) {
   const octets = address.split('.').map(Number);
   if (octets.length !== 4 || octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
     return false;
   }
   const [a, b] = octets;
-  return a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
+  return a === 10 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19));
 }
 
 try {
   const address = readFileSync(0, 'utf8').trim();
-  if (net.isIP(address) !== 4 || !privateIpv4(address)) {
-    throw new Error('QA egress proxy must have one private IPv4 address on the internal network');
+  if (net.isIP(address) !== 4 || !dockerInternalIpv4(address)) {
+    throw new Error('QA egress proxy must have one non-public IPv4 address on the internal network');
   }
   process.stdout.write(`http://${address}:8080\n`);
 } catch (error) {

--- a/qa/proxy-url.mjs
+++ b/qa/proxy-url.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import net from 'node:net';
+
+function privateIpv4(address) {
+  const octets = address.split('.').map(Number);
+  if (octets.length !== 4 || octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return false;
+  }
+  const [a, b] = octets;
+  return a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
+}
+
+try {
+  const address = readFileSync(0, 'utf8').trim();
+  if (net.isIP(address) !== 4 || !privateIpv4(address)) {
+    throw new Error('QA egress proxy must have one private IPv4 address on the internal network');
+  }
+  process.stdout.write(`http://${address}:8080\n`);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`Unable to resolve QA egress proxy address: ${message}\n`);
+  process.exitCode = 1;
+}

--- a/qa/run-local.sh
+++ b/qa/run-local.sh
@@ -440,7 +440,16 @@ docker run --detach --rm --init \
   --entrypoint node \
   "$IMAGE" \
   /opt/juror/qa/egress-proxy.mjs >/dev/null
-docker network connect --gw-priority -1 --alias juror-qa-proxy "$INTERNAL_NETWORK" "$PROXY_NAME"
+docker network connect --gw-priority -1 "$INTERNAL_NETWORK" "$PROXY_NAME"
+# Docker-in-Docker runners can route this private bridge while their embedded DNS
+# fails to resolve container names and aliases. Read the already-created endpoint
+# address from Docker itself, validate that it is private, and avoid that DNS path.
+PROXY_URL="$(
+  docker inspect \
+    --format "{{(index .NetworkSettings.Networks \"$INTERNAL_NETWORK\").IPAddress}}" \
+    "$PROXY_NAME" |
+    node "$ROOT/qa/proxy-url.mjs"
+)"
 for _ in $(seq 1 40); do
   if docker logs "$PROXY_NAME" 2>&1 | grep -q 'juror-qa-egress-proxy ready'; then break; fi
   sleep 0.25
@@ -472,11 +481,11 @@ docker create \
   ${RUNTIME_MOUNTS[@]+"${RUNTIME_MOUNTS[@]}"} \
   ${AUTH_MOUNTS[@]+"${AUTH_MOUNTS[@]}"} \
   ${ENV_ARGS[@]+"${ENV_ARGS[@]}"} \
-  --env HTTP_PROXY=http://juror-qa-proxy:8080 \
-  --env HTTPS_PROXY=http://juror-qa-proxy:8080 \
+  --env "HTTP_PROXY=$PROXY_URL" \
+  --env "HTTPS_PROXY=$PROXY_URL" \
   --env NODE_OPTIONS=--use-env-proxy \
   --env NODE_USE_ENV_PROXY=1 \
-  --env JUROR_QA_BROWSER_PROXY=http://juror-qa-proxy:8080 \
+  --env "JUROR_QA_BROWSER_PROXY=$PROXY_URL" \
   "$IMAGE" \
   --repo-dir /workspace \
   --evidence-dir /evidence \

--- a/test/qa-proxy-address.test.ts
+++ b/test/qa-proxy-address.test.ts
@@ -1,0 +1,36 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const script = path.resolve('qa/proxy-url.mjs');
+
+function resolveProxyUrl(address: string) {
+  return spawnSync(process.execPath, [script], {
+    encoding: 'utf8',
+    input: address,
+  });
+}
+
+describe('QA proxy address resolution', () => {
+  it('uses the inspected private network IP without Docker alias DNS', () => {
+    const result = resolveProxyUrl('172.19.0.2\n');
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe('http://172.19.0.2:8080\n');
+  });
+
+  it.each([
+    ['an empty address', ''],
+    ['a public address', '203.0.113.8'],
+    ['an IPv6 address', 'fd00::2'],
+    ['a loopback address', '127.0.0.1'],
+    ['multiple addresses', '172.19.0.2\n172.19.0.3'],
+  ])('rejects %s', (_label, address) => {
+    const result = resolveProxyUrl(address);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).not.toBe('');
+  });
+});

--- a/test/qa-proxy-address.test.ts
+++ b/test/qa-proxy-address.test.ts
@@ -21,10 +21,22 @@ describe('QA proxy address resolution', () => {
   });
 
   it.each([
+    ['carrier-grade NAT', '100.64.0.2'],
+    ['benchmarking', '198.18.0.2'],
+  ])('accepts Docker internal addresses from the %s range', (_label, address) => {
+    const result = resolveProxyUrl(`${address}\n`);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe(`http://${address}:8080\n`);
+  });
+
+  it.each([
     ['an empty address', ''],
     ['a public address', '203.0.113.8'],
     ['an IPv6 address', 'fd00::2'],
     ['a loopback address', '127.0.0.1'],
+    ['a link-local address', '169.254.0.2'],
+    ['a multicast address', '224.0.0.2'],
     ['multiple addresses', '172.19.0.2\n172.19.0.3'],
   ])('rejects %s', (_label, address) => {
     const result = resolveProxyUrl(address);

--- a/test/supply-chain.test.ts
+++ b/test/supply-chain.test.ts
@@ -170,7 +170,9 @@ describe('supply-chain policy', () => {
     expect(steps[qaIndex]?.run?.trimStart()).toMatch(/^set -euo pipefail\n/);
     expect(steps[qaIndex]?.run).toContain('"$EXACT_IMAGE"');
     expect(steps[qaIndex]?.run).toContain('docker network create --internal');
-    expect(steps[qaIndex]?.run).toContain('JUROR_QA_BROWSER_PROXY=http://juror-qa-proxy:8080');
+    expect(steps[qaIndex]?.run).toContain('proxy-url.mjs');
+    expect(steps[qaIndex]?.run).toContain('JUROR_QA_BROWSER_PROXY=$PROXY_URL');
+    expect(steps[qaIndex]?.run).not.toContain('--alias juror-qa-proxy');
     expect(steps[qaIndex]?.run).toContain('/opt/juror/qa/egress-proxy.mjs');
     expect(steps[qaIndex]?.run).toContain('runtime_status: null');
     expect(steps[qaIndex]?.run).toContain('payload-status.json');
@@ -453,6 +455,7 @@ esac
     const releaseWorkflow = read('.github/workflows/release-qa-image.yml');
     const browser = read('src/qa/browser.ts');
     const proxy = read('qa/egress-proxy.mjs');
+    const proxyUrl = read('qa/proxy-url.mjs');
 
     expect(action).toContain('seccomp=$GITHUB_ACTION_PATH/seccomp_profile.json');
     expect(action).toContain('--cap-drop=ALL');
@@ -475,6 +478,13 @@ esac
     expect(proxy).toContain('const allowed = new Set');
     expect(proxy).toContain("server.on('connect'");
     expect(proxy).toContain('private address denied');
+    expect(proxyUrl).toContain('net.isIP(address) !== 4');
+    expect(action).toContain('node "$GITHUB_ACTION_PATH/proxy-url.mjs"');
+    expect(localRunner).toContain('node "$ROOT/qa/proxy-url.mjs"');
+    expect(action).not.toContain('--alias juror-qa-proxy');
+    expect(localRunner).not.toContain('--alias juror-qa-proxy');
+    expect(action).toContain('--env "JUROR_QA_BROWSER_PROXY=$PROXY_URL"');
+    expect(localRunner).toContain('--env "JUROR_QA_BROWSER_PROXY=$PROXY_URL"');
   });
 
   it('runs native QA image CI for every Docker build input', () => {
@@ -728,6 +738,9 @@ fi
 if [ "\${1:-}" = 'logs' ]; then
   echo 'juror-qa-egress-proxy ready'
 fi
+if [ "\${1:-}" = 'inspect' ]; then
+  echo '172.19.0.2'
+fi
 `,
       );
       chmodSync(join(fakeBin, 'docker'), 0o755);
@@ -828,6 +841,9 @@ if [ "\${1:-}" = 'start' ] && [ "\${2:-}" = '--attach' ]; then
 fi
 if [ "\${1:-}" = 'logs' ]; then
   echo 'juror-qa-egress-proxy ready'
+fi
+if [ "\${1:-}" = 'inspect' ]; then
+  echo '172.19.0.2'
 fi
 `,
       );


### PR DESCRIPTION
## TL;DR

Fix Juror QA on Docker-in-Docker runners where the private runtime can route to the egress proxy but Docker's embedded DNS cannot resolve the proxy container name or alias.

## Summary

- Read the proxy endpoint's internal-network IPv4 address from Docker after attachment.
- Validate that address as RFC1918 before handing it to the credential-bearing runtime.
- Use the validated private URL for Codex and Playwright proxy traffic in both the composite Action and local launcher.
- Preserve the internal-only runtime network and deny-by-default exact-origin egress proxy.

## Review focus

- Fail-closed private IPv4 validation in `qa/proxy-url.mjs`.
- Shell quoting and lifecycle ordering around Docker inspect/network cleanup.
- The runtime remains unable to reach external services except through the existing proxy.

## Test plan

- [x] Regression tests fail before the fix and pass after it.
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test -- --minWorkers=1 --maxWorkers=4` — 819 passed
- [x] `npm run check:secure-refs`
- [x] `npm run check:compatibility`
- [x] Local exact-topology smoke reached OpenAI through the private proxy IP and received the expected explicit 401 for a fake key.
- [x] Live `cfke-docker` DinD probe reproduced alias/name DNS failure, then reached OpenAI through the inspected private proxy IP.
