### PR TITLE
chore: release v1.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juror-ai",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juror-ai",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juror-ai",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Multi-model PR review that shows you the bill. Duplicate findings collapse into one, with optional agreement filtering.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## TL;DR

Release Juror v1.4.3 with the CFKE Docker-in-Docker QA egress reliability fix merged in #75.

## Summary

- update `package.json` to `1.4.3`
- update both root package identities in `package-lock.json` to `1.4.3`
- keep the release commit limited to package identity changes

## Release content

- bypass broken Docker embedded alias DNS by using the inspected internal proxy address
- validate that address remains within supported non-public Docker network ranges
- preserve the credential-bearing runtime's internal-only network and exact-origin egress policy

## Test plan

- [x] package and lockfile identities agree on `1.4.3`
- [x] `test/init.test.ts`: 28/28 pass
- [x] typecheck passes
- [x] immutable Action reference check passes
- [x] #75 passed the full 819-test suite, QA image smoke, secrets scan, and local AI review
