### PR TITLE
ci: migrate host jobs to Runnerhut

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: runnerhut-linux-4vcpu
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -29,7 +29,7 @@ jobs:
   # This repo is public and is handed provider keys at runtime. One committed key is
   # the worst thing that can happen to it, so the check is a build gate rather than a habit.
   secrets-scan:
-    runs-on: ubuntu-latest
+    runs-on: runnerhut-linux-1vcpu
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Assert no provider keys are committed

--- a/.github/workflows/juror.yml
+++ b/.github/workflows/juror.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   review:
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: runnerhut-linux-2vcpu
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:

--- a/.github/workflows/qa-image-ci.yml
+++ b/.github/workflows/qa-image-ci.yml
@@ -30,6 +30,8 @@ permissions:
 
 jobs:
   smoke:
+    # Runnerhut is intentionally host-only. This job validates Docker image
+    # isolation and therefore remains on GitHub's Linux Docker runner.
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/release-qa-image.yml
+++ b/.github/workflows/release-qa-image.yml
@@ -13,6 +13,8 @@ permissions: {}
 jobs:
   image:
     if: github.repository == 'Juror-AI/juror' && !github.event.release.prerelease
+    # Multi-architecture Buildx, QEMU and nested container validation require
+    # a Docker-capable Linux runner; Runnerhut rejects this workflow by design.
     runs-on: ubuntu-latest
     permissions:
       attestations: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ concurrency:
 jobs:
   publish:
     if: github.repository == 'Juror-AI/juror' && !github.event.release.prerelease
+    # npm trusted publishing currently accepts GitHub-hosted runners only.
+    # Keep the OIDC publication boundary here even though validation is host-only.
     runs-on: ubuntu-latest
     permissions:
       attestations: write


### PR DESCRIPTION
## Summary

- run the full test suite on Runnerhut Linux x64 (4 vCPU)
- run secret scanning on Runnerhut Linux x64 (1 vCPU)
- run Juror review on Runnerhut Linux x64 (2 vCPU)
- keep Docker/Buildx jobs on GitHub-hosted Linux runners
- keep npm trusted publishing on GitHub-hosted Linux because npm does not support self-hosted trusted publishing

## Validation

- `npm ci`
- `npm run typecheck`
- `npm run build`
- `npm run compatibility`
- full Vitest suite: 53 files / 823 tests passed
- secure action-reference check
