### PR TITLE
fix(cloud): clean up cancelled sandboxes

### DIFF
--- a/cloud/test/security.test.ts
+++ b/cloud/test/security.test.ts
@@ -53,6 +53,8 @@ describe('webhook security boundaries', () => {
     expect(workflows).toContain("replace(/(?:sk|fw|gh[opsu])-");
     expect(workflows).toContain("PATH: '/tmp/juror-bin:/usr/local/bin:/usr/bin:/bin'");
     expect(workflows).toContain('reviewerDiagnostics: string[]');
+    expect(workflows).toContain("sleepAfter: '40m'");
+    expect(workflows).not.toContain('keepAlive: true');
     expect(workflows).toMatch(/finally\s*{\s*await sandbox\.destroy\(\)/);
     expect(runner).toContain('x-access-token:${githubPlaceholder}@github.com');
     expect(runner).toContain('child.stdout.resume()');

--- a/cloud/worker/github-webhook.ts
+++ b/cloud/worker/github-webhook.ts
@@ -5,6 +5,7 @@ import { appendRunEvent } from './events';
 import { githubApi } from './github';
 import { missingProviderSecrets } from './providers';
 import { initialRepositorySettings } from './repository-settings';
+import { destroyRunSandbox } from './workflows';
 
 type JsonObject = Record<string, any>;
 
@@ -203,7 +204,10 @@ export async function createRun(env: Env, input: { kind: 'review' | 'qa'; identi
   // throughout creation and a final check closes the remaining create/terminate gap.
   try {
     const cancelled = await env.DB.prepare(`SELECT 1 AS cancelled FROM run WHERE id = ? AND status = 'cancelled'`).bind(runId).first();
-    if (cancelled) await (await workflow.get(workflowId)).terminate();
+    if (cancelled) {
+      await destroyRunSandbox(env, input.kind, runId);
+      await (await workflow.get(workflowId)).terminate();
+    }
   } catch { /* The Workflow itself also refuses a cancelled row before Sandbox admission. */ }
   return runId;
 }
@@ -212,6 +216,7 @@ async function cancelOlderReviews(env: Env, repositoryId: string, prNumber: numb
   const rows = await env.DB.prepare(`SELECT id, workflow_instance_id FROM run WHERE repository_id = ? AND pr_number = ? AND kind = 'review' AND revision_sha != ? AND status IN ('queued', 'running')`)
     .bind(repositoryId, prNumber, headSha).all<{ id: string; workflow_instance_id: string | null }>();
   for (const row of rows.results) {
+    await destroyRunSandbox(env, 'review', row.id);
     if (row.workflow_instance_id) {
       try { await (await env.REVIEW_WORKFLOW.get(row.workflow_instance_id)).terminate(); } catch { /* The workflow may already be terminal. */ }
     }
@@ -237,6 +242,7 @@ async function cancelRunsForAccessRevocation(env: Env, repositoryIds: string[]):
         catch (error) { console.warn(JSON.stringify({ event: 'access_revocation_event_failed', runId: row.id, error: error instanceof Error ? error.message : String(error) })); }
       }
       if (!row.workflow_instance_id) continue;
+      await destroyRunSandbox(env, row.kind, row.id);
       const workflow = row.kind === 'review' ? env.REVIEW_WORKFLOW : env.QA_WORKFLOW;
       const instance = await workflow.get(row.workflow_instance_id);
       let clearWorkflowHandle = false;

--- a/cloud/worker/index.ts
+++ b/cloud/worker/index.ts
@@ -13,7 +13,7 @@ import { githubApi } from './github';
 import { discoverGitHubInstallations, installationProvisioningPayload } from './github-installations';
 import { createBillingPortal, createCheckout, verifyStripeSignature } from './stripe';
 import { verifyHmacHeader, createSignedToken, timingSafeEqual } from './crypto';
-import { enqueueNextRepositoryQa, sweepQueuedQaAdmissions } from './workflows';
+import { destroyRunSandbox, enqueueNextRepositoryQa, sweepQueuedQaAdmissions } from './workflows';
 import { corpusExportResponse, runCorpusRetention, type QueueMessage } from './corpus';
 import { processQueueBatch } from './queue';
 import { reconcileStripeMeterEvents } from './billing';
@@ -384,6 +384,7 @@ async function authorizeRun(c: Context<AppEnv>) {
 app.post('/api/runs/:id/cancel', async (c) => {
   const run = await authorizeRun(c);
   if (!['queued', 'running'].includes(run.status)) return c.json({ error: { code: 'not_cancellable', message: 'Run is already terminal' }, requestId: c.get('requestId') }, 409);
+  await destroyRunSandbox(c.env, run.kind, run.id);
   if (run.workflow_instance_id) {
     const workflow = run.kind === 'review' ? c.env.REVIEW_WORKFLOW : c.env.QA_WORKFLOW;
     try { await (await workflow.get(run.workflow_instance_id)).terminate(); } catch { /* Terminal races are resolved by the conditional update. */ }

--- a/cloud/worker/workflows.ts
+++ b/cloud/worker/workflows.ts
@@ -165,6 +165,20 @@ const EVIDENCE_ROOT = '/tmp/juror-evidence/';
 const MAX_EVIDENCE_FILE_BYTES = 100 * 1024 * 1024;
 const MAX_EVIDENCE_TOTAL_BYTES = 300 * 1024 * 1024;
 
+/**
+ * Workflow termination can interrupt a running step before its `finally` block
+ * reaches the Sandbox. Call this from every external cancellation path so a
+ * cancelled run cannot retain a heartbeat-enabled container.
+ */
+export async function destroyRunSandbox(env: Env, kind: 'review' | 'qa', runId: string): Promise<void> {
+  const namespace = kind === 'review' ? env.ReviewSandbox : env.QaSandbox;
+  try {
+    await getSandbox(namespace, runId.toLowerCase(), { normalizeId: true }).destroy();
+  } catch (error) {
+    console.warn(JSON.stringify({ event: 'sandbox_cleanup_failed', runId, kind, error: error instanceof Error ? error.message : String(error) }));
+  }
+}
+
 function safeEvidenceContentType(kind: string, mimeType?: string): string {
   if (kind === 'screenshot') return 'image/png';
   if (kind === 'video') return 'video/webm';
@@ -187,7 +201,10 @@ async function sha256Hex(bytes: Uint8Array): Promise<string> {
 
 async function executeInSandbox(env: Env, manifest: RunManifest): Promise<{ reportJson: string; durationMs: number; cpuTimeMs: number; evidenceBytes: number; reviewerDiagnostics: string[] }> {
   const namespace = manifest.kind === 'review' ? env.ReviewSandbox : env.QaSandbox;
-  const sandbox = getSandbox(namespace, manifest.runId.toLowerCase(), { normalizeId: true, keepAlive: true });
+  // A review can run for up to 30 minutes. A finite inactivity timeout protects
+  // against a Worker or Workflow termination that prevents the finalizer below
+  // from running, unlike keepAlive which persists indefinitely.
+  const sandbox = getSandbox(namespace, manifest.runId.toLowerCase(), { normalizeId: true, sleepAfter: '40m' });
   const started = Date.now();
   try {
     const targetHosts = qaTargetHosts(manifest.kind, manifest.allowedOrigins);

--- a/cloud/worker/workspace-delete.ts
+++ b/cloud/worker/workspace-delete.ts
@@ -1,5 +1,6 @@
 import type { Env } from './env';
 import { deleteWorkspaceCorpusObjects } from './corpus';
+import { destroyRunSandbox } from './workflows';
 
 async function deleteObjectKeys(bucket: R2Bucket, keys: string[]): Promise<void> {
   for (let index = 0; index < keys.length; index += 1000) await bucket.delete(keys.slice(index, index + 1000));
@@ -13,6 +14,7 @@ async function cancelWorkspaceRuns(env: Env, workspaceId: string): Promise<void>
   const active = await env.DB.prepare(`SELECT id, kind, workflow_instance_id FROM run WHERE workspace_id = ? AND workflow_instance_id IS NOT NULL AND (completed_at IS NULL OR status = 'cancelled')`)
     .bind(workspaceId).all<{ id: string; kind: 'review' | 'qa'; workflow_instance_id: string }>();
   for (const run of active.results) {
+    await destroyRunSandbox(env, run.kind, run.id);
     try {
       const workflow = run.kind === 'review' ? env.REVIEW_WORKFLOW : env.QA_WORKFLOW;
       await (await workflow.get(run.workflow_instance_id)).terminate();


### PR DESCRIPTION
## TL;DR

Prevent cancelled Juror runs from retaining Cloudflare Sandbox containers indefinitely, and bound inactive sandbox lifetime to 40 minutes.

## Contribution type

Maintenance.

## What changed and why

- Destroy each run sandbox before every workflow-termination path.
- Replace persistent keep-alive with a finite 40-minute inactivity timeout.

## Integration evidence

- Exact model and client/harness versions: Not applicable; no model or harness behavior changed.
- Serving provider and route: Not applicable.
- Authentication shape (variable names only; never values): Not applicable.
- Dated pricing source and cache/context-tier behavior: Cloudflare Containers pricing, verified 2026-08-24; inactive pre-warmed capacity is not billed.
- Redacted reproducible fixture paths: Not applicable.
- Missing model, malformed output, timeout, and partial-cost behavior: Existing execution behavior retained; cancelled workflows now explicitly destroy their sandbox.

## Security boundaries

- Cleanup uses the existing review/QA Durable Object bindings and does not introduce credentials, routes, or model-provider access.
- Cancellation, supersession, access revocation, and workspace deletion now remove sandbox state before workflow termination.

## Validation

- [x] `npm run typecheck`
- [ ] `npm run build` (not run)
- [ ] `npm run check:compatibility` (not available in cloud package)
- [ ] `npm test` (57 tests passed; 2 suites are blocked by an existing `@cloudflare/containers` module-resolution error)
- [ ] `npm run check:secure-refs` (not available in cloud package)
- [x] Focused `npx vitest run test/security.test.ts`
- [x] Generated docs/fixtures are updated, redacted, and contain no repository secrets (not applicable).

## Issue

None.