### PR TITLE
fix(mcp): accept public refresh-capable clients

### DIFF
--- a/cloud/test/dcr.test.ts
+++ b/cloud/test/dcr.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { normalizePublicDcrRegistration } from '../worker/dcr';
+
+describe('public Dynamic Client Registration', () => {
+  it('normalizes an omitted client authentication method to the public profile', () => {
+    expect(normalizePublicDcrRegistration({
+      client_name: 'ChatGPT',
+      redirect_uris: ['https://chatgpt.com/connector_platform_oauth_redirect'],
+      grant_types: ['authorization_code', 'refresh_token'],
+    })).toMatchObject({
+      token_endpoint_auth_method: 'none',
+      grant_types: ['authorization_code', 'refresh_token'],
+    });
+  });
+
+  it('defaults an otherwise valid registration to authorization_code only', () => {
+    expect(normalizePublicDcrRegistration({ client_name: 'OpenAI' })).toMatchObject({
+      token_endpoint_auth_method: 'none',
+      grant_types: ['authorization_code'],
+    });
+  });
+
+  it.each([
+    { token_endpoint_auth_method: 'client_secret_basic' },
+    { client_secret: 'never-accepted' },
+    { grant_types: ['refresh_token'] },
+    { grant_types: ['authorization_code', 'client_credentials'] },
+  ])('rejects registrations outside the public PKCE profile: %o', (metadata) => {
+    expect(normalizePublicDcrRegistration(metadata)).toBeNull();
+  });
+});

--- a/cloud/test/mcp-contract.test.ts
+++ b/cloud/test/mcp-contract.test.ts
@@ -42,9 +42,11 @@ describe('Juror MCP contract', () => {
       readFile(new URL('../worker/index.ts', import.meta.url), 'utf8'),
     ]);
     expect(auth).toContain('accessTokenExpiresIn: 300');
-    expect(auth).toContain("grantTypes: ['authorization_code']");
+    expect(auth).toContain("grantTypes: ['authorization_code', 'refresh_token']");
     expect(auth).toContain('clientRegistrationRequirePKCE: true');
-    expect(worker).toContain("token_endpoint_auth_method !== 'none'");
+    expect(worker).toContain('normalizePublicDcrRegistration');
     expect(worker).toContain('PKCE S256 only');
+    expect(worker).toContain("'/.well-known/openai-apps-challenge'");
+    expect(worker).toContain("'cache-control': 'no-store'");
   });
 });

--- a/cloud/worker/auth.ts
+++ b/cloud/worker/auth.ts
@@ -66,7 +66,7 @@ export function createAuth(env: Env, requestUrl?: string) {
         scopes: ['juror.read', 'juror.reviews.write'],
         resources: [{ identifier: mcpResourceUrl(env, requestUrl), name: 'Juror MCP', allowedScopes: ['juror.read', 'juror.reviews.write'], accessTokenTtl: 300 }],
         accessTokenExpiresIn: 300,
-        grantTypes: ['authorization_code'],
+        grantTypes: ['authorization_code', 'refresh_token'],
         allowDynamicClientRegistration: true,
         allowUnauthenticatedClientRegistration: true,
         clientRegistrationRequirePKCE: true,

--- a/cloud/worker/dcr.ts
+++ b/cloud/worker/dcr.ts
@@ -1,0 +1,32 @@
+/**
+ * Normalize Dynamic Client Registration metadata to the narrow public-client
+ * profile supported by Juror MCP. OAuth clients are never allowed to bring a
+ * secret: Better Auth will enforce PKCE S256 for every registered client.
+ */
+const publicGrantTypes = new Set(['authorization_code', 'refresh_token']);
+
+export function normalizePublicDcrRegistration(input: unknown): Record<string, unknown> | null {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return null;
+  const registration = input as Record<string, unknown>;
+  const authMethod = registration.token_endpoint_auth_method;
+  const grantTypes = registration.grant_types;
+
+  if (registration.client_secret !== undefined) return null;
+  if (authMethod !== undefined && authMethod !== 'none') return null;
+
+  const normalizedGrantTypes = grantTypes === undefined ? ['authorization_code'] : grantTypes;
+  if (!Array.isArray(normalizedGrantTypes)
+    || normalizedGrantTypes.length === 0
+    || !normalizedGrantTypes.includes('authorization_code')
+    || normalizedGrantTypes.some((grantType) => typeof grantType !== 'string' || !publicGrantTypes.has(grantType))) {
+    return null;
+  }
+
+  // RFC 7591 defaults this field to client_secret_basic. The OpenAI scan can
+  // omit it, so pin the safe public-client value before it reaches Better Auth.
+  return {
+    ...registration,
+    token_endpoint_auth_method: 'none',
+    grant_types: normalizedGrantTypes,
+  };
+}

--- a/cloud/worker/env.ts
+++ b/cloud/worker/env.ts
@@ -17,6 +17,8 @@ declare global {
       STRIPE_SECRET_KEY?: string;
       STRIPE_WEBHOOK_SECRET?: string;
       OPENAI_API_KEY?: string;
+      /** Short-lived OpenAI Plugin directory domain-ownership challenge. */
+      OPENAI_APPS_CHALLENGE_TOKEN?: string;
       ANTHROPIC_API_KEY?: string;
       XAI_API_KEY?: string;
       DEEPSEEK_API_KEY?: string;
@@ -55,6 +57,8 @@ export type Env = GeneratedBindings & {
   EVIDENCE_SIGNING_SECRET: string;
   CORPUS_MASTER_KEY_B64?: string;
   OPENAI_API_KEY?: string;
+  /** Short-lived OpenAI Plugin directory domain-ownership challenge. */
+  OPENAI_APPS_CHALLENGE_TOKEN?: string;
   ANTHROPIC_API_KEY?: string;
   XAI_API_KEY?: string;
   DEEPSEEK_API_KEY?: string;

--- a/cloud/worker/index.ts
+++ b/cloud/worker/index.ts
@@ -24,6 +24,7 @@ import { anyReviewPresetReady, qaProviderReady, reviewPresetReadiness } from './
 import { repositorySettingsSchema, resolveSecretHeadersCiphertext } from './repository-settings';
 import { handleMcpRequest } from './mcp';
 import { launchBrowserHostedReview, launchBrowserHostedRerun, ReviewServiceError } from './review-service';
+import { normalizePublicDcrRegistration } from './dcr';
 
 export { ContainerProxy, JurorSandbox, QaSandbox, ReviewSandbox } from './sandbox';
 export { HostedQaWorkflow, HostedReviewWorkflow } from './workflows';
@@ -57,20 +58,35 @@ app.post('/api/auth/oauth2/register', async (c) => {
   if (!c.req.header('content-type')?.toLowerCase().includes('application/json')) {
     return c.json({ error: 'invalid_client_metadata', error_description: 'Dynamic registration requires application/json.' }, 400, { 'cache-control': 'no-store' });
   }
-  let registration: { token_endpoint_auth_method?: unknown; grant_types?: unknown; client_secret?: unknown };
+  let registration: unknown;
   try { registration = await c.req.raw.clone().json(); }
   catch { return c.json({ error: 'invalid_client_metadata', error_description: 'Dynamic registration body must be valid JSON.' }, 400, { 'cache-control': 'no-store' }); }
-  const codeOnly = registration.grant_types === undefined || (Array.isArray(registration.grant_types) && registration.grant_types.length === 1 && registration.grant_types[0] === 'authorization_code');
-  if (registration.token_endpoint_auth_method !== 'none' || !codeOnly || registration.client_secret !== undefined) {
-    return c.json({ error: 'invalid_client_metadata', error_description: 'Juror accepts public authorization-code clients with PKCE S256 only.' }, 400, { 'cache-control': 'no-store' });
+  const publicRegistration = normalizePublicDcrRegistration(registration);
+  if (!publicRegistration) {
+    return c.json({ error: 'invalid_client_metadata', error_description: 'Juror accepts public authorization-code clients, with optional refresh-token rotation, using PKCE S256 only.' }, 400, { 'cache-control': 'no-store' });
   }
-  return createAuth(c.env, c.req.url).handler(c.req.raw);
+  const headers = new Headers(c.req.raw.headers);
+  // The normalized JSON differs from the client body, so retain no stale
+  // length header when constructing the request passed to Better Auth.
+  headers.delete('content-length');
+  headers.set('content-type', 'application/json');
+  return createAuth(c.env, c.req.url).handler(new Request(c.req.raw.url, {
+    method: 'POST', headers, body: JSON.stringify(publicRegistration),
+  }));
 });
 app.all('/api/auth/*', (c) => createAuth(c.env, c.req.url).handler(c.req.raw));
 // These discovery routes must always reach the Worker; Wrangler routes them ahead of the SPA assets.
 app.all('/.well-known/oauth-protected-resource', (c) => createAuth(c.env, c.req.url).handler(c.req.raw));
 app.all('/.well-known/oauth-protected-resource/mcp', (c) => createAuth(c.env, c.req.url).handler(c.req.raw));
 app.all('/.well-known/oauth-authorization-server/api/auth', (c) => createAuth(c.env, c.req.url).handler(c.req.raw));
+// OpenAI's public Plugin directory verifies the publisher's production domain
+// with a short-lived challenge. The value is set as a production secret after
+// the portal supplies it, rather than being committed or cached with assets.
+app.get('/.well-known/openai-apps-challenge', (c) => {
+  const challenge = c.env.OPENAI_APPS_CHALLENGE_TOKEN;
+  if (!challenge) return c.notFound();
+  return c.text(challenge, 200, { 'cache-control': 'no-store' });
+});
 // New remote listings use Streamable HTTP. The modern transport is POST-only;
 // do not expose an SSE compatibility route.
 app.post('/mcp', (c) => handleMcpRequest(c.env, c.req.raw));


### PR DESCRIPTION
## TL;DR
Allow OpenAI’s DCR scanner to register Juror as a PKCE-only public client when it declares refresh-token support.

## Summary
- Normalize RFC 7591 public-client metadata before forwarding it to Better Auth.
- Keep confidential and non-PKCE grant profiles rejected.
- Add the no-store OpenAI domain-verification challenge endpoint.

## Review focus
- The normalization must never admit a client secret or non-public grant.
- The rewritten request must not forward a stale content length.

## Test plan
- [x] `cd cloud && npm test`
- [x] `cd cloud && npm run typecheck:worker`
- [x] `cd cloud && npm run typecheck`
- [x] `git diff --check`