### PR TITLE
Add GLM-5.3 to the jury via the opencode harness

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -7,7 +7,7 @@ harnesses, and versioned pricing table. It describes tested Juror configuration,
 promise that an external provider will keep a model available. Run
 `npm run docs:compatibility` after changing any of those inputs.
 
-Pricing table last checked: **2026-08-11**.
+Pricing table last checked: **2026-08-29**.
 
 ## Built-in models
 
@@ -15,6 +15,7 @@ Pricing table last checked: **2026-08-11**.
 |---|---|---|---|---|---|---|
 | Opus 5<br><sub>`claude-opus-5`</sub> | Anthropic<br><sub>`JUROR_ANTHROPIC_API_KEY`</sub> | Claude Code<br><sub>`claude-code`</sub> | `claude-opus-5` | `high`, `ultra` | provider-reported; unknown on malformed output | [2026-08-06](https://www.anthropic.com/pricing#api) |
 | DeepSeek V4 Flash<br><sub>`deepseek-v4-flash-0731`</sub> | Fireworks<br><sub>`JUROR_FIREWORKS_API_KEY`</sub> | DeepSeek<br><sub>`deepseek`</sub> | `accounts/fireworks/models/deepseek-v4-flash-0731` | `fast`, `ultra` | provider-usage estimated; unknown without usage events | [2026-08-06](https://models.dev) |
+| GLM-5.3<br><sub>`glm-5p3`</sub> | Fireworks<br><sub>`JUROR_FIREWORKS_API_KEY`</sub> | opencode<br><sub>`opencode`</sub> | `accounts/fireworks/models/glm-5p3` | `balanced` | provider-reported per step; unknown on malformed output | [2026-08-29](https://models.dev/) |
 | GPT-5.6 Luna<br><sub>`gpt-5.6-luna`</sub> | OpenAI<br><sub>`JUROR_OPENAI_API_KEY`</sub> | Codex<br><sub>`codex`</sub> | `gpt-5.6-luna` | `fast`, `ultra` | token-estimated; unknown without usage | [2026-08-07](https://developers.openai.com/api/docs/models/gpt-5.6-luna) |
 | GPT-5.6 Sol<br><sub>`gpt-5.6-sol`</sub> | OpenAI<br><sub>`JUROR_OPENAI_API_KEY`</sub> | Codex<br><sub>`codex`</sub> | `gpt-5.6-sol` | `high`, `ultra` | token-estimated; unknown without usage | [2026-08-06](https://openai.com/api/pricing/) |
 | GPT-5.6 Terra<br><sub>`gpt-5.6-terra`</sub> | OpenAI<br><sub>`JUROR_OPENAI_API_KEY`</sub> | Codex<br><sub>`codex`</sub> | `gpt-5.6-terra` | `balanced`, `ultra` | token-estimated; unknown without usage | [2026-08-06](https://developers.openai.com/api/docs/models/gpt-5.6-terra) |

--- a/src/config.ts
+++ b/src/config.ts
@@ -195,6 +195,17 @@ const BUILTIN_MODELS: Record<string, ModelConfig> = {
     pricing_key: 'accounts/fireworks/models/deepseek-v4-flash-0731',
     args: { reasoning_effort: 'high' },
   },
+  'glm-5p3': {
+    id: 'glm-5p3',
+    harness: 'opencode',
+    enabled: true,
+    secret: 'JUROR_FIREWORKS_API_KEY',
+    label: 'GLM-5.3',
+    base_url: 'https://api.fireworks.ai/inference/v1',
+    harness_model: 'accounts/fireworks/models/glm-5p3',
+    pricing_key: 'accounts/fireworks/models/glm-5p3',
+    args: { variant: 'high' },
+  },
 };
 
 interface PresetDefinition {
@@ -224,7 +235,7 @@ const PRESET_DEFINITIONS: Record<ReviewPreset, PresetDefinition> = {
     },
   },
   balanced: {
-    modelIds: ['gpt-5.6-terra', 'grok-4.5', 'kimi-k3'],
+    modelIds: ['gpt-5.6-terra', 'grok-4.5', 'kimi-k3', 'glm-5p3'],
     consensusModel: 'kimi-k3',
   },
   high: {

--- a/src/cost/pricing.json
+++ b/src/cost/pricing.json
@@ -1,6 +1,6 @@
 {
   "$meta": {
-    "updated": "2026-08-11",
+    "updated": "2026-08-29",
     "note": "USD per million tokens (Mtok). Rates live under \"models\"; every top-level key starting with \"$\" is metadata and is ignored by loadPricing(), which also accepts a flat table so a hand-written override file need not know about the wrapper. Every entry carries the page it was read from and the date it was checked — a weekly CI job diffs this file against those pages and opens a PR on drift, because stale prices are the obvious failure mode for a tool whose pitch is cost honesty. Two things that are easy to get wrong and are deliberate here: (1) long_context is a cliff, not a slope — crossing threshold_input_tokens reprices the ENTIRE request, so a 199k-token Grok review costs half what a 201k one does; (2) cache writes are NOT free (OpenAI bills them at 1.25x uncached input for GPT-5.6 and later, Anthropic bills them too), so a missing cache_write_per_mtok means the provider publishes no separate write rate — grok-4.5 and the Fireworks models — and computeCost() falls back to that tier's input rate and says so in the receipt note. Omit a rate you do not know rather than inventing one: an absent entry makes computeCost() print \"unknown\", which is the only honest answer."
   },
   "models": {
@@ -132,6 +132,14 @@
       "context_window": 1000000,
       "source": "https://models.dev",
       "updated": "2026-08-06"
+    },
+    "accounts/fireworks/models/glm-5p3": {
+      "input_per_mtok": 1.4,
+      "output_per_mtok": 4.4,
+      "cache_read_per_mtok": 0.26,
+      "context_window": 1000000,
+      "source": "https://models.dev/",
+      "updated": "2026-08-29"
     },
     "accounts/fireworks/models/kimi-k3": {
       "input_per_mtok": 3.0,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -102,7 +102,7 @@ describe('defaultConfig', () => {
     expect(fast.models.map((m) => m.args?.['reasoning_effort'] ?? m.args?.['variant'])).toEqual(['low', 'high']);
     expect(fast.consensus.referee_model).toBe('deepseek-v4-flash-0731');
     // No longer the default, so this is the only place its membership is pinned.
-    expect(balanced.models.map((m) => m.id)).toEqual(['gpt-5.6-terra', 'grok-4.5', 'kimi-k3']);
+    expect(balanced.models.map((m) => m.id)).toEqual(['gpt-5.6-terra', 'grok-4.5', 'kimi-k3', 'glm-5p3']);
     expect(balanced.models[0]?.args?.['reasoning_effort']).toBe('max');
     expect(balanced.models[1]?.args?.['reasoning_effort']).toBe('high');
     expect(balanced.consensus.referee_model).toBe('kimi-k3');


### PR DESCRIPTION
## What

Adds `glm-5p3` (Fireworks GLM-5.3) as a built-in jury model, driven by the opencode harness with `variant: high`.

## Changes

- `src/config.ts` — new `glm-5p3` entry in `BUILTIN_MODELS` (`harness: opencode`, `secret: JUROR_FIREWORKS_API_KEY`, `harness_model`/`pricing_key: accounts/fireworks/models/glm-5p3`)
- `src/cost/pricing.json` — rates cited from models.dev: \.4 / \.4 per Mtok (input/output), \.26 cache read, 1M context; `.updated` bumped accordingly
- `balanced` preset — `glm-5p3` joins the jury for model diversity; consensus referee stays on `kimi-k3`
- `docs/compatibility.md` — regenerated via `npm run docs:compatibility`
- `test/config.test.ts` — balanced preset assertion updated

## Validation

- `npm run typecheck` — clean
- `npm test` — all config/cost/compatibility tests pass (80/80). The only full-suite failures are pre-existing Windows environment issues in `worktree.test.ts`/`trusted-config.test.ts` (Unix-only `/usr/bin/env`, symlink privileges) — verified identical on the unmodified base.

Closes #13