### PR TITLE
Add MiniMax M3 to the jury via the opencode harness

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -7,7 +7,7 @@ harnesses, and versioned pricing table. It describes tested Juror configuration,
 promise that an external provider will keep a model available. Run
 `npm run docs:compatibility` after changing any of those inputs.
 
-Pricing table last checked: **2026-08-29**.
+Pricing table last checked: **2026-08-31**.
 
 ## Built-in models
 
@@ -21,6 +21,7 @@ Pricing table last checked: **2026-08-29**.
 | GPT-5.6 Terra<br><sub>`gpt-5.6-terra`</sub> | OpenAI<br><sub>`JUROR_OPENAI_API_KEY`</sub> | Codex<br><sub>`codex`</sub> | `gpt-5.6-terra` | `balanced`, `ultra` | token-estimated; unknown without usage | [2026-08-06](https://developers.openai.com/api/docs/models/gpt-5.6-terra) |
 | Grok 4.5<br><sub>`grok-4.5`</sub> | xAI<br><sub>`JUROR_XAI_API_KEY`</sub> | Grok Build<br><sub>`grok-build`</sub> | `grok-4.5` | `balanced`, `high`, `ultra` | provider-reported when present; unknown otherwise | [2026-08-06](https://docs.x.ai/docs/models) |
 | Kimi K3<br><sub>`kimi-k3`</sub> | Fireworks<br><sub>`JUROR_FIREWORKS_API_KEY`</sub> | Kimi Code CLI<br><sub>`kimi-code`</sub> | `accounts/fireworks/models/kimi-k3` | `balanced`, `ultra` | usage-estimated; unknown without usage records | [2026-08-06](https://fireworks.ai/models/fireworks/kimi-k3) |
+| MiniMax M3<br><sub>`minimax-m3`</sub> | Fireworks<br><sub>`JUROR_FIREWORKS_API_KEY`</sub> | opencode<br><sub>`opencode`</sub> | `accounts/fireworks/models/minimax-m3` | `balanced` | provider-reported per step; unknown on malformed output | [2026-08-31](https://models.dev/) |
 | DeepSeek V4 Flash<br><sub>`openrouter-deepseek-v4-flash`</sub> | OpenRouter<br><sub>`JUROR_OPENROUTER_API_KEY`</sub> | Generic OpenAI<br><sub>`generic-openai`</sub> | `deepseek/deepseek-v4-flash-0731` | `starter` | provider-reported; price fallback | [2026-08-11](https://openrouter.ai/api/v1/models) |
 | GPT-5.6 Luna<br><sub>`openrouter-gpt-5.6-luna`</sub> | OpenRouter<br><sub>`JUROR_OPENROUTER_API_KEY`</sub> | Generic OpenAI<br><sub>`generic-openai`</sub> | `openai/gpt-5.6-luna` | `starter` | provider-reported; price fallback | [2026-08-11](https://openrouter.ai/api/v1/models) |
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -206,6 +206,17 @@ const BUILTIN_MODELS: Record<string, ModelConfig> = {
     pricing_key: 'accounts/fireworks/models/glm-5p3',
     args: { variant: 'high' },
   },
+  'minimax-m3': {
+    id: 'minimax-m3',
+    harness: 'opencode',
+    enabled: true,
+    secret: 'JUROR_FIREWORKS_API_KEY',
+    label: 'MiniMax M3',
+    base_url: 'https://api.fireworks.ai/inference/v1',
+    harness_model: 'accounts/fireworks/models/minimax-m3',
+    pricing_key: 'accounts/fireworks/models/minimax-m3',
+    args: { variant: 'high' },
+  },
 };
 
 interface PresetDefinition {
@@ -235,7 +246,7 @@ const PRESET_DEFINITIONS: Record<ReviewPreset, PresetDefinition> = {
     },
   },
   balanced: {
-    modelIds: ['gpt-5.6-terra', 'grok-4.5', 'kimi-k3', 'glm-5p3'],
+    modelIds: ['gpt-5.6-terra', 'grok-4.5', 'kimi-k3', 'glm-5p3', 'minimax-m3'],
     consensusModel: 'kimi-k3',
   },
   high: {

--- a/src/cost/pricing.json
+++ b/src/cost/pricing.json
@@ -1,6 +1,6 @@
 {
   "$meta": {
-    "updated": "2026-08-29",
+    "updated": "2026-08-31",
     "note": "USD per million tokens (Mtok). Rates live under \"models\"; every top-level key starting with \"$\" is metadata and is ignored by loadPricing(), which also accepts a flat table so a hand-written override file need not know about the wrapper. Every entry carries the page it was read from and the date it was checked — a weekly CI job diffs this file against those pages and opens a PR on drift, because stale prices are the obvious failure mode for a tool whose pitch is cost honesty. Two things that are easy to get wrong and are deliberate here: (1) long_context is a cliff, not a slope — crossing threshold_input_tokens reprices the ENTIRE request, so a 199k-token Grok review costs half what a 201k one does; (2) cache writes are NOT free (OpenAI bills them at 1.25x uncached input for GPT-5.6 and later, Anthropic bills them too), so a missing cache_write_per_mtok means the provider publishes no separate write rate — grok-4.5 and the Fireworks models — and computeCost() falls back to that tier's input rate and says so in the receipt note. Omit a rate you do not know rather than inventing one: an absent entry makes computeCost() print \"unknown\", which is the only honest answer."
   },
   "models": {
@@ -140,6 +140,14 @@
       "context_window": 1000000,
       "source": "https://models.dev/",
       "updated": "2026-08-29"
+    },
+    "accounts/fireworks/models/minimax-m3": {
+      "input_per_mtok": 0.3,
+      "output_per_mtok": 1.2,
+      "cache_read_per_mtok": 0.06,
+      "context_window": 512000,
+      "source": "https://models.dev/",
+      "updated": "2026-08-31"
     },
     "accounts/fireworks/models/kimi-k3": {
       "input_per_mtok": 3.0,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -102,7 +102,7 @@ describe('defaultConfig', () => {
     expect(fast.models.map((m) => m.args?.['reasoning_effort'] ?? m.args?.['variant'])).toEqual(['low', 'high']);
     expect(fast.consensus.referee_model).toBe('deepseek-v4-flash-0731');
     // No longer the default, so this is the only place its membership is pinned.
-    expect(balanced.models.map((m) => m.id)).toEqual(['gpt-5.6-terra', 'grok-4.5', 'kimi-k3', 'glm-5p3']);
+    expect(balanced.models.map((m) => m.id)).toEqual(['gpt-5.6-terra', 'grok-4.5', 'kimi-k3', 'glm-5p3', 'minimax-m3']);
     expect(balanced.models[0]?.args?.['reasoning_effort']).toBe('max');
     expect(balanced.models[1]?.args?.['reasoning_effort']).toBe('high');
     expect(balanced.consensus.referee_model).toBe('kimi-k3');


### PR DESCRIPTION
Closes #14.

Adds `minimax-m3` (Fireworks MiniMax M3) as a built-in model using the opencode harness with `variant: high`, following the GLM-5.3 PR #90 pattern: cites pricing from models.dev, and joins it to the balanced preset for jury diversity. Consensus stays on kimi-k3. Adds the compatibility matrix row and bumps the pricing table date.

Pricing verified live against models.dev (`fireworks-ai` → `accounts/fireworks/models/minimax-m3`): input $0.30/Mtok, output $1.20/Mtok, cache_read $0.06/Mtok, context 512k — all values match.

`test/config.test.ts`: 37/37 passing.