### PR TITLE
fix(qa): validate browser startup on runners

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juror-ai",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juror-ai",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juror-ai",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Multi-model PR review that shows you the bill. Duplicate findings collapse into one, with optional agreement filtering.",
   "homepage": "https://juror.dev",
   "bugs": {

--- a/qa/action.yml
+++ b/qa/action.yml
@@ -306,9 +306,54 @@ runs:
           echo "retention-days=$RETENTION"
         } >> "$GITHUB_OUTPUT"
 
+    - name: Verify Chromium on the QA runner
+      id: browser
+      if: steps.policy.outputs.enabled == 'true'
+      shell: bash
+      env:
+        EXACT_IMAGE: ${{ steps.image.outputs.ref }}
+        RUNTIME_USER: ${{ steps.runtime.outputs.runtime-user }}
+        JUROR_OPENAI_API_KEY: ''
+        OPENAI_API_KEY: ''
+        JUROR_ANTHROPIC_API_KEY: ''
+        ANTHROPIC_API_KEY: ''
+        JUROR_XAI_API_KEY: ''
+        XAI_API_KEY: ''
+        JUROR_FIREWORKS_API_KEY: ''
+        FIREWORKS_API_KEY: ''
+        JUROR_OPENROUTER_API_KEY: ''
+        OPENROUTER_API_KEY: ''
+        JUROR_QA_SECRETS_B64: ''
+        CODEX_HOME: ''
+      run: |
+        set -euo pipefail
+        if ! [[ "$RUNTIME_USER" =~ ^[0-9]+:[0-9]+$ ]]; then
+          echo "::error::Prepared QA browser user must be a numeric UID:GID"
+          exit 1
+        fi
+        RUNTIME_UID="${RUNTIME_USER%%:*}"
+        RUNTIME_GID="${RUNTIME_USER##*:}"
+        docker run --rm --init \
+          --pull=never \
+          --network none \
+          --read-only \
+          --tmpfs /tmp:rw,nosuid,nodev,size=256m \
+          --tmpfs "/home/pwuser:rw,nosuid,nodev,size=64m,uid=$RUNTIME_UID,gid=$RUNTIME_GID,mode=0700" \
+          --shm-size=1g \
+          --user "$RUNTIME_USER" \
+          --cap-drop=ALL \
+          --cap-add=SYS_CHROOT \
+          --security-opt "seccomp=$GITHUB_ACTION_PATH/seccomp_profile.json" \
+          --pids-limit=512 \
+          --memory=4g \
+          --cpus=2 \
+          --entrypoint node \
+          "$EXACT_IMAGE" \
+          /opt/juror/qa/smoke-chromium.mjs
+
     - name: Publish QA setup failure
       id: preflight
-      if: ${{ failure() && (steps.image.outcome == 'failure' || steps.runtime.outcome == 'failure' || steps.policy.outcome == 'failure') }}
+      if: ${{ failure() && (steps.image.outcome == 'failure' || steps.runtime.outcome == 'failure' || steps.policy.outcome == 'failure' || steps.browser.outcome == 'failure') }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
@@ -324,7 +369,7 @@ runs:
         RUNTIME_USER: ${{ steps.runtime.outputs.runtime-user }}
         RUNTIME_PREPARED: ${{ steps.runtime.outcome == 'success' }}
         INPUT_POST: ${{ inputs.post }}
-        JUROR_QA_PREFLIGHT_PHASE: ${{ steps.image.outcome == 'failure' && 'image' || steps.runtime.outcome == 'failure' && 'runtime' || 'policy' }}
+        JUROR_QA_PREFLIGHT_PHASE: ${{ steps.image.outcome == 'failure' && 'image' || steps.runtime.outcome == 'failure' && 'runtime' || steps.policy.outcome == 'failure' && 'policy' || 'browser' }}
         JUROR_OPENAI_API_KEY: ''
         OPENAI_API_KEY: ''
         JUROR_ANTHROPIC_API_KEY: ''

--- a/qa/finalize-fallback.mjs
+++ b/qa/finalize-fallback.mjs
@@ -24,6 +24,10 @@ const preflightPhases = new Map([
     title: 'The trusted QA policy could not be evaluated',
     detail: 'Juror stopped before starting QA because its trusted policy gate did not complete.',
   }],
+  ['browser', {
+    title: 'The sandboxed Chromium could not start on this QA runner',
+    detail: 'Juror stopped before model execution because the released browser runtime failed its runner-local sandbox check.',
+  }],
 ]);
 
 function validRepository(value) {

--- a/src/qa/browser.ts
+++ b/src/qa/browser.ts
@@ -122,6 +122,8 @@ export interface QaBrokerState {
   attempts: QaAttemptRecord[];
   operationCount: number;
   agentFinish: QaAgentFinish | null;
+  /** Fixed controller-owned category; never contains browser or page error text. */
+  infrastructureFailure?: 'chromium_launch_failed' | null;
 }
 
 export interface QaBrowserBrokerOptions {
@@ -164,6 +166,8 @@ export interface QaBrowserBrokerOptions {
   /** Trusted, controller-supplied Playwright storage state for fast local iteration. */
   storageState?: string;
   beforeAttempt?: (scenarioId: string, attempt: 1 | 2, signal: AbortSignal) => Promise<void>;
+  /** @internal Browser launcher override used only by Playwright broker tests. */
+  launchBrowser?: (options: LaunchOptions) => Promise<Browser>;
   /** @internal Shorter fixed setup window used only by the Playwright broker tests. */
   sensitiveSetupWindowMs?: number;
 }
@@ -204,6 +208,7 @@ const MAX_SUPPORT_SESSION_LIFETIME_MS = 60 * 60 * 1_000;
 const SUPPORT_SESSION_CLOCK_TOLERANCE_MS = 30_000;
 const SENSITIVE_SETUP_WINDOW_MS = 10_000;
 const SENSITIVE_SETUP_DEADLINE_MARGIN_MS = 250;
+const BROWSER_LAUNCH_TIMEOUT_MS = 30_000;
 const AUTH_TEXT_OMITTED = 'Authenticated browser text omitted by policy.';
 const AUTH_URL_OMITTED = 'Authenticated browser URL omitted by policy.';
 const AUTH_BROWSER_ERROR_OMITTED = 'Authenticated browser operation failed; page-controlled details were omitted.';
@@ -592,6 +597,7 @@ export class QaBrowserBroker {
   readonly #interruptController = new AbortController();
   #browser: Browser | null = null;
   #browserStarted = false;
+  #infrastructureFailure: QaBrokerState['infrastructureFailure'] = null;
   #pendingSetupContext: BrowserContext | null = null;
   #storageState: string | undefined;
   #plan: QaBrokerPlan | null = null;
@@ -709,15 +715,26 @@ export class QaBrowserBroker {
 
   async #ensureBrowser(timeoutMs?: number): Promise<void> {
     if (this.#browser) return;
+    if (this.#infrastructureFailure === 'chromium_launch_failed') {
+      throw new SafeBrokerError('Chromium could not start on the QA runner');
+    }
     this.#throwIfInterrupted();
     this.#browserStarted = true;
-    const browser = await chromium.launch({
-      ...launchOptions(
-        this.#options.headless ?? true,
-        this.#options.chromiumSandbox ?? true,
-      ),
-      ...(timeoutMs === undefined ? {} : { timeout: Math.max(1, timeoutMs) }),
-    });
+    let browser: Browser;
+    try {
+      const launchBrowser = this.#options.launchBrowser
+        ?? ((options: LaunchOptions) => chromium.launch(options));
+      browser = await launchBrowser({
+        ...launchOptions(
+          this.#options.headless ?? true,
+          this.#options.chromiumSandbox ?? true,
+        ),
+        ...(timeoutMs === undefined ? {} : { timeout: Math.max(1, timeoutMs) }),
+      });
+    } catch {
+      this.#infrastructureFailure = 'chromium_launch_failed';
+      throw new SafeBrokerError('Chromium could not start on the QA runner');
+    }
     if (this.#interruptController.signal.aborted) {
       await browser.close().catch(() => {});
       this.#throwIfInterrupted();
@@ -731,6 +748,7 @@ export class QaBrowserBroker {
       attempts: structuredClone(this.#attempts),
       operationCount: this.#operationCount,
       agentFinish: this.#agentFinish ? structuredClone(this.#agentFinish) : null,
+      infrastructureFailure: this.#infrastructureFailure,
     };
   }
 
@@ -972,6 +990,24 @@ export class QaBrowserBroker {
         this.#interruptController.signal,
       );
       return { started: true, scenario_id: scenario.id, attempt, viewport: scenario.viewport };
+    }
+
+    // Chromium startup is credential-free and page-independent, so it does not
+    // belong inside the constant-time authentication envelope. DinD runners can
+    // legitimately need longer than that envelope to launch a healthy browser.
+    // Keep launch bounded by both its own cap and the remaining overall run budget.
+    const browserLaunchBudgetMs = Math.min(
+      BROWSER_LAUNCH_TIMEOUT_MS,
+      this.#options.timeoutMs - (Date.now() - this.#startedAt)
+        - setupWindowMs - SENSITIVE_SETUP_DEADLINE_MARGIN_MS,
+    );
+    if (browserLaunchBudgetMs < 1) {
+      throw new SafeBrokerError('The remaining QA run budget cannot start Chromium and authenticate safely');
+    }
+    await this.#ensureBrowser(browserLaunchBudgetMs);
+    const remainingRunMs = this.#options.timeoutMs - (Date.now() - this.#startedAt);
+    if (remainingRunMs < setupWindowMs + SENSITIVE_SETUP_DEADLINE_MARGIN_MS) {
+      throw new SafeBrokerError('Chromium startup left too little QA run budget for sealed authentication');
     }
 
     const setupStartedAt = Date.now();

--- a/src/qa/run.ts
+++ b/src/qa/run.ts
@@ -585,6 +585,7 @@ export function classifyQaOutcome(
   cancelled = false,
 ): QaOutcome {
   if (cancelled) return 'cancelled';
+  if (state.infrastructureFailure) return 'infrastructure_error';
   if (agent.timedOut || agent.exitCode !== 0 || !agent.completed || !state.plan || !state.agentFinish) {
     return 'infrastructure_error';
   }
@@ -1199,6 +1200,9 @@ export async function runQa(options: RunQaOptions): Promise<QaRunResult> {
       ...(options.signal ? { signal: options.signal } : {}),
     });
     state = broker.state();
+    if (state.infrastructureFailure === 'chromium_launch_failed') {
+      warnings.push('QA browser startup: sandboxed Chromium could not start on this runner');
+    }
     warnings.push(...agent.diagnostics);
   } catch (error) {
     warnings.push(`QA runtime: ${errorMessage(error)}`);

--- a/test/qa-browser.test.ts
+++ b/test/qa-browser.test.ts
@@ -848,6 +848,61 @@ describe.sequential('QaBrowserBroker policy boundary', () => {
     await broker.close();
   });
 
+  it('does not charge credential-free Chromium startup to the sealed authentication window', async () => {
+    const evidenceDir = evidenceDirectory();
+    const browserLaunchDelayMs = 2_100;
+    const broker = new QaBrowserBroker(brokerOptions(evidenceDir, {
+      authSteps: [{ action: 'navigate', url: '/' }],
+      sensitiveSetupWindowMs: 2_000,
+      timeoutMs: 30_000,
+      launchBrowser: async (options) => {
+        await new Promise((resolve) => setTimeout(resolve, browserLaunchDelayMs));
+        return chromium.launch(options);
+      },
+    }));
+    await broker.initialize();
+    try {
+      await broker.handle('submit_plan', plan());
+      const startedAt = Date.now();
+      await expect(broker.handle('start_scenario', {
+        scenario_id: 'exercise-fixture',
+        attempt: 1,
+      })).resolves.toEqual({ accepted: true, observation: 'sealed' });
+      expect(Date.now() - startedAt).toBeGreaterThanOrEqual(
+        browserLaunchDelayMs + 2_000 - 100,
+      );
+      expect(broker.browserVersion()).not.toBe('unknown');
+    } finally {
+      await broker.close();
+    }
+  }, 35_000);
+
+  it('records a sealed, categorical infrastructure failure when Chromium cannot launch', async () => {
+    const launchErrorCanary = 'runner-launch-error-canary';
+    const broker = new QaBrowserBroker(brokerOptions(evidenceDirectory(), {
+      authSteps: [{ action: 'navigate', url: '/' }],
+      launchBrowser: async () => {
+        throw new Error(launchErrorCanary);
+      },
+    }));
+    await broker.initialize();
+    try {
+      await broker.handle('submit_plan', plan());
+      await expect(broker.handle('start_scenario', {
+        scenario_id: 'exercise-fixture',
+        attempt: 1,
+      })).rejects.toThrow('Authenticated browser operation failed');
+      expect(broker.state()).toMatchObject({
+        attempts: [],
+        infrastructureFailure: 'chromium_launch_failed',
+      });
+      expect(JSON.stringify(broker.state())).not.toContain(launchErrorCanary);
+      expect(broker.browserVersion()).toBe('unknown');
+    } finally {
+      await broker.close();
+    }
+  });
+
   it('rejects oversized supplied storage state before Chromium starts', async () => {
     const evidenceDir = evidenceDirectory();
     const storageState = join(evidenceDir, 'oversized-state.json');

--- a/test/qa-finalize.test.ts
+++ b/test/qa-finalize.test.ts
@@ -173,6 +173,7 @@ describe('finalizeQaEvidence', () => {
     ['image', 'released QA image could not be verified'],
     ['runtime', 'isolated QA runtime could not be prepared'],
     ['policy', 'trusted QA policy could not be evaluated'],
+    ['browser', 'sandboxed Chromium could not start on this QA runner'],
   ])('publishes static preflight %s failure output without reflecting environment text', (phase, expected) => {
     const scratch = mkdtempSync(join(tmpdir(), 'juror-qa-preflight-'));
     try {

--- a/test/qa-run.test.ts
+++ b/test/qa-run.test.ts
@@ -294,6 +294,15 @@ describe('QA outcome classification safety gates', () => {
     )).toBe('cancelled');
   });
 
+  it('classifies a categorical Chromium launch failure as infrastructure', () => {
+    expect(classifyQaOutcome(
+      { ...state(plan()), infrastructureFailure: 'chromium_launch_failed' },
+      target(),
+      agent,
+      clean,
+    )).toBe('infrastructure_error');
+  });
+
   it('blocks cleanup failure even for a no-surface plan', () => {
     expect(classifyQaOutcome(
       state(plan('no_testable_surface')),

--- a/test/supply-chain.test.ts
+++ b/test/supply-chain.test.ts
@@ -138,12 +138,15 @@ describe('supply-chain policy', () => {
     const steps = action.runs.steps;
     const verifyIndex = steps.findIndex((step) => step.name === 'Resolve and verify the released QA image');
     const policyIndex = steps.findIndex((step) => step.name === 'Read trusted QA policy before credential handoff');
+    const browserIndex = steps.findIndex((step) => step.name === 'Verify Chromium on the QA runner');
     const qaIndex = steps.findIndex((step) => step.name === 'Run Juror QA in the verified image');
 
     expect(verifyIndex).toBeGreaterThanOrEqual(0);
     expect(qaIndex).toBeGreaterThan(verifyIndex);
     expect(policyIndex).toBeGreaterThan(verifyIndex);
+    expect(browserIndex).toBeGreaterThan(policyIndex);
     expect(qaIndex).toBeGreaterThan(policyIndex);
+    expect(qaIndex).toBeGreaterThan(browserIndex);
     expect(action.inputs).not.toHaveProperty('codex-version');
     expect(action.inputs).not.toHaveProperty('allow-origins');
     expect(steps.some((step) => step.uses?.startsWith('actions/cache@'))).toBe(false);
@@ -180,6 +183,13 @@ describe('supply-chain policy', () => {
     expect(steps[qaIndex]?.run).toContain('configuredRetention ?? fallbackRetention');
     expect(steps[policyIndex]?.run).not.toContain('--allow-origin');
     expect(steps[qaIndex]?.run).not.toContain('--allow-origin');
+    expect(steps[browserIndex]?.if).toBe("steps.policy.outputs.enabled == 'true'");
+    expect(steps[browserIndex]?.env?.['JUROR_OPENAI_API_KEY']).toBe('');
+    expect(steps[browserIndex]?.env?.['JUROR_QA_SECRETS_B64']).toBe('');
+    expect(steps[browserIndex]?.run).toContain('/opt/juror/qa/smoke-chromium.mjs');
+    expect(steps[browserIndex]?.run).toContain('--network none');
+    expect(steps[browserIndex]?.run).toContain('--user "$RUNTIME_USER"');
+    expect(steps[browserIndex]?.run).toContain('seccomp=$GITHUB_ACTION_PATH/seccomp_profile.json');
   });
 
   it('uploads immutable payload and result artifacts around finalization', () => {
@@ -273,15 +283,16 @@ describe('supply-chain policy', () => {
     const image = steps.findIndex((step) => step.id === 'image');
     const runtime = steps.findIndex((step) => step.id === 'runtime');
     const policy = steps.findIndex((step) => step.id === 'policy');
+    const browser = steps.findIndex((step) => step.id === 'browser');
     const preflight = steps.findIndex((step) => step.name === 'Publish QA setup failure');
     const disabled = steps.findIndex((step) => step.name === 'Record disabled QA outcome');
     const conclusion = steps.findIndex((step) => step.name === 'Apply QA conclusion');
     const setup = steps[preflight];
 
-    expect(preflight).toBe(policy + 1);
+    expect(preflight).toBe(browser + 1);
     expect(preflight).toBeGreaterThan(image);
     expect(preflight).toBeGreaterThan(runtime);
-    expect(setup?.if).toBe("${{ failure() && (steps.image.outcome == 'failure' || steps.runtime.outcome == 'failure' || steps.policy.outcome == 'failure') }}");
+    expect(setup?.if).toContain("steps.browser.outcome == 'failure'");
     expect(setup?.env?.['JUROR_QA_PREFLIGHT_PHASE']).toContain("steps.image.outcome == 'failure'");
     for (const key of [
       'JUROR_OPENAI_API_KEY', 'OPENAI_API_KEY', 'JUROR_ANTHROPIC_API_KEY', 'ANTHROPIC_API_KEY',
@@ -461,7 +472,7 @@ esac
     expect(action).toContain('--cap-drop=ALL');
     expect(action).toContain('--cap-add=SYS_CHROOT');
     expect(dockerfile).toContain('HOME=/home/pwuser');
-    expect(action.match(/uid=\$RUNTIME_UID,gid=\$RUNTIME_GID,mode=0700/g)).toHaveLength(2);
+    expect(action.match(/uid=\$RUNTIME_UID,gid=\$RUNTIME_GID,mode=0700/g)).toHaveLength(3);
     expect(localRunner.match(/uid=\$CONTAINER_UID,gid=\$CONTAINER_GID,mode=0700/g)).toHaveLength(2);
     expect(releaseWorkflow).toContain('PW_UID="$(docker run --rm --entrypoint id "$EXACT_IMAGE" -u pwuser)"');
     expect(releaseWorkflow).toContain('uid=$PW_UID,gid=$PW_GID,mode=0700');


### PR DESCRIPTION
## TL;DR
Separates credential-free Chromium startup from the sealed authentication deadline and adds a runner-local sandbox smoke check before model execution. Releases the fix as version 1.4.4.

## Summary
- launch Chromium outside the constant-time authenticated setup window with a bounded runner budget
- classify launch failures as sanitized infrastructure errors instead of empty blocked journeys
- exercise the released image with the caller runner UID and production sandbox flags before QA
- add broker, finalizer, outcome, and Action contract regressions

## Review focus
- authenticated timing remains sealed after the browser is ready
- the preflight receives no model or application credentials
- launch errors expose only a fixed controller-owned category

## Test plan
- [x] npm test (847 tests)
- [x] npm run typecheck
- [x] npm run build
- [x] npm run check:secure-refs
- [x] npm pack --ignore-scripts --dry-run
- [x] QA image CI hardened Chromium smoke on GitHub-hosted Linux
- [ ] post-release smoke on textcortex/platform cfke-docker

## CI note
Runnerhut-backed checks are queued across the repository, including unrelated PRs older than 9 hours. GitHub-hosted cloud and QA-image checks passed.