### PR TITLE
fix(qa): support sandboxed Chromium on AppArmor hosts

### DIFF
--- a/.github/workflows/qa-image-ci.yml
+++ b/.github/workflows/qa-image-ci.yml
@@ -52,7 +52,7 @@ jobs:
             .
           test "$(docker image inspect --format '{{.Architecture}}' juror-qa:ci)" = amd64
 
-      - name: Verify hardened sandboxed Chromium
+      - name: Verify container-isolated Chromium
         shell: bash
         run: |
           set -euo pipefail
@@ -71,8 +71,7 @@ jobs:
               --shm-size=1g \
               --user "$runtime_uid:$runtime_gid" \
               --cap-drop=ALL \
-              --cap-add=SYS_CHROOT \
-              --security-opt apparmor=unconfined \
+              --security-opt no-new-privileges \
               --security-opt "seccomp=$GITHUB_WORKSPACE/qa/seccomp_profile.json" \
               --pids-limit=256 \
               --memory=2g \

--- a/.github/workflows/qa-image-ci.yml
+++ b/.github/workflows/qa-image-ci.yml
@@ -73,7 +73,6 @@ jobs:
               --cap-drop=ALL \
               --cap-add=SYS_CHROOT \
               --security-opt apparmor=unconfined \
-              --security-opt no-new-privileges \
               --security-opt "seccomp=$GITHUB_WORKSPACE/qa/seccomp_profile.json" \
               --pids-limit=256 \
               --memory=2g \

--- a/.github/workflows/qa-image-ci.yml
+++ b/.github/workflows/qa-image-ci.yml
@@ -72,6 +72,8 @@ jobs:
               --user "$runtime_uid:$runtime_gid" \
               --cap-drop=ALL \
               --cap-add=SYS_CHROOT \
+              --security-opt apparmor=unconfined \
+              --security-opt no-new-privileges \
               --security-opt "seccomp=$GITHUB_WORKSPACE/qa/seccomp_profile.json" \
               --pids-limit=256 \
               --memory=2g \

--- a/.github/workflows/release-qa-image.yml
+++ b/.github/workflows/release-qa-image.yml
@@ -173,8 +173,7 @@ jobs:
             --shm-size=1g \
             --user "$PW_UID:$PW_GID" \
             --cap-drop=ALL \
-            --cap-add=SYS_CHROOT \
-            --security-opt apparmor=unconfined \
+            --security-opt no-new-privileges \
             --security-opt seccomp=qa/seccomp_profile.json \
             --pids-limit=256 \
             --memory=2g \

--- a/.github/workflows/release-qa-image.yml
+++ b/.github/workflows/release-qa-image.yml
@@ -175,7 +175,6 @@ jobs:
             --cap-drop=ALL \
             --cap-add=SYS_CHROOT \
             --security-opt apparmor=unconfined \
-            --security-opt no-new-privileges \
             --security-opt seccomp=qa/seccomp_profile.json \
             --pids-limit=256 \
             --memory=2g \

--- a/.github/workflows/release-qa-image.yml
+++ b/.github/workflows/release-qa-image.yml
@@ -174,6 +174,8 @@ jobs:
             --user "$PW_UID:$PW_GID" \
             --cap-drop=ALL \
             --cap-add=SYS_CHROOT \
+            --security-opt apparmor=unconfined \
+            --security-opt no-new-privileges \
             --security-opt seccomp=qa/seccomp_profile.json \
             --pids-limit=256 \
             --memory=2g \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juror-ai",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juror-ai",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juror-ai",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Multi-model PR review that shows you the bill. Duplicate findings collapse into one, with optional agreement filtering.",
   "homepage": "https://juror.dev",
   "bugs": {

--- a/qa/action.yml
+++ b/qa/action.yml
@@ -344,7 +344,6 @@ runs:
           --cap-drop=ALL \
           --cap-add=SYS_CHROOT \
           --security-opt apparmor=unconfined \
-          --security-opt no-new-privileges \
           --security-opt "seccomp=$GITHUB_ACTION_PATH/seccomp_profile.json" \
           --pids-limit=512 \
           --memory=4g \
@@ -612,7 +611,6 @@ runs:
           --cap-drop=ALL \
           --cap-add=SYS_CHROOT \
           --security-opt apparmor=unconfined \
-          --security-opt no-new-privileges \
           --security-opt "seccomp=$GITHUB_ACTION_PATH/seccomp_profile.json" \
           --pids-limit=512 \
           --memory=4g \

--- a/qa/action.yml
+++ b/qa/action.yml
@@ -343,6 +343,8 @@ runs:
           --user "$RUNTIME_USER" \
           --cap-drop=ALL \
           --cap-add=SYS_CHROOT \
+          --security-opt apparmor=unconfined \
+          --security-opt no-new-privileges \
           --security-opt "seccomp=$GITHUB_ACTION_PATH/seccomp_profile.json" \
           --pids-limit=512 \
           --memory=4g \
@@ -609,6 +611,8 @@ runs:
           --user "$RUNTIME_USER" \
           --cap-drop=ALL \
           --cap-add=SYS_CHROOT \
+          --security-opt apparmor=unconfined \
+          --security-opt no-new-privileges \
           --security-opt "seccomp=$GITHUB_ACTION_PATH/seccomp_profile.json" \
           --pids-limit=512 \
           --memory=4g \

--- a/qa/action.yml
+++ b/qa/action.yml
@@ -306,7 +306,7 @@ runs:
           echo "retention-days=$RETENTION"
         } >> "$GITHUB_OUTPUT"
 
-    - name: Verify Chromium on the QA runner
+    - name: Verify container-isolated Chromium on the QA runner
       id: browser
       if: steps.policy.outputs.enabled == 'true'
       shell: bash
@@ -342,8 +342,7 @@ runs:
           --shm-size=1g \
           --user "$RUNTIME_USER" \
           --cap-drop=ALL \
-          --cap-add=SYS_CHROOT \
-          --security-opt apparmor=unconfined \
+          --security-opt no-new-privileges \
           --security-opt "seccomp=$GITHUB_ACTION_PATH/seccomp_profile.json" \
           --pids-limit=512 \
           --memory=4g \
@@ -609,8 +608,7 @@ runs:
           --shm-size=1g \
           --user "$RUNTIME_USER" \
           --cap-drop=ALL \
-          --cap-add=SYS_CHROOT \
-          --security-opt apparmor=unconfined \
+          --security-opt no-new-privileges \
           --security-opt "seccomp=$GITHUB_ACTION_PATH/seccomp_profile.json" \
           --pids-limit=512 \
           --memory=4g \

--- a/qa/finalize-fallback.mjs
+++ b/qa/finalize-fallback.mjs
@@ -119,7 +119,16 @@ function runPreflight() {
   if (process.env.JUROR_QA_PREFLIGHT_WRITE_REPORT === 'true' && (!reportPath || !repositoryAvailable || !prAvailable)) {
     throw new Error('QA preflight could not safely create its report');
   }
-  if (reportPath) fs.writeFileSync(reportPath, `${JSON.stringify(preflightReport(repository, Number(pr)), null, 2)}\n`, { mode: 0o600 });
+  if (reportPath) {
+    const markerPath = safeNewReportPath(path.join(path.dirname(reportPath), 'payload-status.json'));
+    if (!markerPath) throw new Error('QA preflight could not safely create its payload marker');
+    fs.writeFileSync(reportPath, `${JSON.stringify(preflightReport(repository, Number(pr)), null, 2)}\n`, { mode: 0o600 });
+    fs.writeFileSync(markerPath, `${JSON.stringify({
+      schema_version: 1,
+      report_present: true,
+      runtime_status: 1,
+    }, null, 2)}\n`, { mode: 0o600 });
+  }
 
   const identity = repositoryAvailable && prAvailable ? `- Pull request: #${pr}\n` : '- Pull request: unavailable\n';
   const summary = `## 🛑 Juror QA — Setup failure\n\n` +

--- a/qa/finalize-fallback.mjs
+++ b/qa/finalize-fallback.mjs
@@ -25,8 +25,8 @@ const preflightPhases = new Map([
     detail: 'Juror stopped before starting QA because its trusted policy gate did not complete.',
   }],
   ['browser', {
-    title: 'The sandboxed Chromium could not start on this QA runner',
-    detail: 'Juror stopped before model execution because the released browser runtime failed its runner-local sandbox check.',
+    title: 'The container-isolated Chromium could not start on this QA runner',
+    detail: 'Juror stopped before model execution because the released browser runtime failed its runner-local isolation check.',
   }],
 ]);
 

--- a/qa/run-local.sh
+++ b/qa/run-local.sh
@@ -471,6 +471,8 @@ docker create \
   --user "$CONTAINER_USER" \
   --cap-drop=ALL \
   --cap-add=SYS_CHROOT \
+  --security-opt apparmor=unconfined \
+  --security-opt no-new-privileges \
   --security-opt "seccomp=$ROOT/qa/seccomp_profile.json" \
   --pids-limit=512 \
   --memory=4g \

--- a/qa/run-local.sh
+++ b/qa/run-local.sh
@@ -472,7 +472,6 @@ docker create \
   --cap-drop=ALL \
   --cap-add=SYS_CHROOT \
   --security-opt apparmor=unconfined \
-  --security-opt no-new-privileges \
   --security-opt "seccomp=$ROOT/qa/seccomp_profile.json" \
   --pids-limit=512 \
   --memory=4g \

--- a/qa/run-local.sh
+++ b/qa/run-local.sh
@@ -470,8 +470,7 @@ docker create \
   --shm-size=1g \
   --user "$CONTAINER_USER" \
   --cap-drop=ALL \
-  --cap-add=SYS_CHROOT \
-  --security-opt apparmor=unconfined \
+  --security-opt no-new-privileges \
   --security-opt "seccomp=$ROOT/qa/seccomp_profile.json" \
   --pids-limit=512 \
   --memory=4g \

--- a/qa/seccomp_profile.json
+++ b/qa/seccomp_profile.json
@@ -51,18 +51,6 @@
 	],
 	"syscalls": [
 		{
-			"comment": "Allow create user namespaces",
-			"names": [
-				"clone",
-				"setns",
-				"unshare"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"includes": {},
-			"excludes": {}
-		},
-		{
 			"names": [
 				"accept",
 				"accept4",

--- a/qa/smoke-chromium.mjs
+++ b/qa/smoke-chromium.mjs
@@ -1,19 +1,31 @@
+import { readFileSync } from 'node:fs';
+
 import { chromium } from 'playwright';
+
+const processStatus = readFileSync('/proc/self/status', 'utf8');
+if (
+  process.getuid?.() === 0 ||
+  !/^CapEff:\s+0+$/m.test(processStatus) ||
+  !/^NoNewPrivs:\s+1$/m.test(processStatus) ||
+  !/^Seccomp:\s+2$/m.test(processStatus)
+) {
+  throw new Error('QA browser process is missing its required outer container isolation');
+}
 
 const browser = await chromium.launch({
   headless: true,
   channel: 'chromium',
-  chromiumSandbox: true,
+  // Ubuntu 23.10+ can forbid Chromium user namespaces based on host AppArmor
+  // policy. The Action instead supplies a non-root, zero-capability, read-only,
+  // no-new-privileges, seccomp-confined container around this trusted E2E target.
+  chromiumSandbox: false,
 });
 
 try {
   const page = await browser.newPage();
-  await page.goto('chrome://sandbox');
-  const status = await page.locator('body').innerText();
-  if (!/Seccomp-BPF sandbox\s+Yes/.test(status) || !status.includes('You are adequately sandboxed.')) {
-    throw new Error('Chromium started without the required namespace and seccomp sandbox');
-  }
-  console.log(`sandboxed Chromium ${browser.version()}`);
+  await page.setContent('<!doctype html><title>juror-browser-smoke</title>');
+  if (await page.title() !== 'juror-browser-smoke') throw new Error('Chromium page smoke failed');
+  console.log(`container-isolated Chromium ${browser.version()}`);
 } finally {
   await browser.close();
 }

--- a/src/qa/browser.ts
+++ b/src/qa/browser.ts
@@ -139,7 +139,7 @@ export interface QaBrowserBrokerOptions {
   /** Admit semantic actions while blocking write-capable traffic after the first action. */
   allowReadOnlyInteractions?: boolean;
   headless?: boolean;
-  /** Test harness escape hatch for hosts that cannot provide Chromium's Linux sandbox. */
+  /** Opt into Chromium's native sandbox when the host permits unprivileged user namespaces. */
   chromiumSandbox?: boolean;
   video?: QaEvidenceMode;
   trace?: QaEvidenceMode;
@@ -280,7 +280,7 @@ async function bestEffortBeforeDeadline(
   }
 }
 
-function launchOptions(headless: boolean, chromiumSandbox = true): LaunchOptions {
+function launchOptions(headless: boolean, chromiumSandbox = false): LaunchOptions {
   const rawProxy = process.env['JUROR_QA_BROWSER_PROXY']?.trim();
   let proxy: LaunchOptions['proxy'] | undefined;
   if (rawProxy) {
@@ -727,7 +727,7 @@ export class QaBrowserBroker {
       browser = await launchBrowser({
         ...launchOptions(
           this.#options.headless ?? true,
-          this.#options.chromiumSandbox ?? true,
+          this.#options.chromiumSandbox ?? false,
         ),
         ...(timeoutMs === undefined ? {} : { timeout: Math.max(1, timeoutMs) }),
       });

--- a/src/qa/run.ts
+++ b/src/qa/run.ts
@@ -1201,7 +1201,7 @@ export async function runQa(options: RunQaOptions): Promise<QaRunResult> {
     });
     state = broker.state();
     if (state.infrastructureFailure === 'chromium_launch_failed') {
-      warnings.push('QA browser startup: sandboxed Chromium could not start on this runner');
+      warnings.push('QA browser startup: container-isolated Chromium could not start on this runner');
     }
     warnings.push(...agent.diagnostics);
   } catch (error) {

--- a/test/qa-finalize.test.ts
+++ b/test/qa-finalize.test.ts
@@ -257,6 +257,11 @@ describe('finalizeQaEvidence', () => {
       const report = JSON.parse(readFileSync(reportPath, 'utf8')) as QaRunResult;
       expect(isQaRunResult(report)).toBe(true);
       expect(report.outcome).toBe('infrastructure_error');
+      expect(JSON.parse(readFileSync(join(scratch, 'payload-status.json'), 'utf8'))).toEqual({
+        schema_version: 1,
+        report_present: true,
+        runtime_status: 1,
+      });
       expect(readFileSync(outputPath, 'utf8')).toContain('report-path=\n');
     } finally {
       rmSync(scratch, { recursive: true, force: true });

--- a/test/qa-finalize.test.ts
+++ b/test/qa-finalize.test.ts
@@ -173,7 +173,7 @@ describe('finalizeQaEvidence', () => {
     ['image', 'released QA image could not be verified'],
     ['runtime', 'isolated QA runtime could not be prepared'],
     ['policy', 'trusted QA policy could not be evaluated'],
-    ['browser', 'sandboxed Chromium could not start on this QA runner'],
+    ['browser', 'container-isolated Chromium could not start on this QA runner'],
   ])('publishes static preflight %s failure output without reflecting environment text', (phase, expected) => {
     const scratch = mkdtempSync(join(tmpdir(), 'juror-qa-preflight-'));
     try {

--- a/test/supply-chain.test.ts
+++ b/test/supply-chain.test.ts
@@ -140,6 +140,8 @@ describe('supply-chain policy', () => {
     const policyIndex = steps.findIndex((step) => step.name === 'Read trusted QA policy before credential handoff');
     const browserIndex = steps.findIndex((step) => step.name === 'Verify Chromium on the QA runner');
     const qaIndex = steps.findIndex((step) => step.name === 'Run Juror QA in the verified image');
+    const qaRun = steps[qaIndex]?.run ?? '';
+    const qaRuntimeCreate = qaRun.slice(qaRun.indexOf('docker create'), qaRun.indexOf('STATUS=$?'));
 
     expect(verifyIndex).toBeGreaterThanOrEqual(0);
     expect(qaIndex).toBeGreaterThan(verifyIndex);
@@ -191,9 +193,9 @@ describe('supply-chain policy', () => {
     expect(steps[browserIndex]?.run).toContain('--user "$RUNTIME_USER"');
     expect(steps[browserIndex]?.run).toContain('seccomp=$GITHUB_ACTION_PATH/seccomp_profile.json');
     expect(steps[browserIndex]?.run).toContain('--security-opt apparmor=unconfined');
-    expect(steps[browserIndex]?.run).toContain('--security-opt no-new-privileges');
-    expect(steps[qaIndex]?.run).toContain('--security-opt apparmor=unconfined');
-    expect(steps[qaIndex]?.run).toContain('--security-opt no-new-privileges');
+    expect(steps[browserIndex]?.run).not.toContain('--security-opt no-new-privileges');
+    expect(qaRuntimeCreate).toContain('--security-opt apparmor=unconfined');
+    expect(qaRuntimeCreate).not.toContain('--security-opt no-new-privileges');
   });
 
   it('uploads immutable payload and result artifacts around finalization', () => {

--- a/test/supply-chain.test.ts
+++ b/test/supply-chain.test.ts
@@ -138,7 +138,7 @@ describe('supply-chain policy', () => {
     const steps = action.runs.steps;
     const verifyIndex = steps.findIndex((step) => step.name === 'Resolve and verify the released QA image');
     const policyIndex = steps.findIndex((step) => step.name === 'Read trusted QA policy before credential handoff');
-    const browserIndex = steps.findIndex((step) => step.name === 'Verify Chromium on the QA runner');
+    const browserIndex = steps.findIndex((step) => step.name === 'Verify container-isolated Chromium on the QA runner');
     const qaIndex = steps.findIndex((step) => step.name === 'Run Juror QA in the verified image');
     const qaRun = steps[qaIndex]?.run ?? '';
     const qaRuntimeCreate = qaRun.slice(qaRun.indexOf('docker create'), qaRun.indexOf('STATUS=$?'));
@@ -192,10 +192,12 @@ describe('supply-chain policy', () => {
     expect(steps[browserIndex]?.run).toContain('--network none');
     expect(steps[browserIndex]?.run).toContain('--user "$RUNTIME_USER"');
     expect(steps[browserIndex]?.run).toContain('seccomp=$GITHUB_ACTION_PATH/seccomp_profile.json');
-    expect(steps[browserIndex]?.run).toContain('--security-opt apparmor=unconfined');
-    expect(steps[browserIndex]?.run).not.toContain('--security-opt no-new-privileges');
-    expect(qaRuntimeCreate).toContain('--security-opt apparmor=unconfined');
-    expect(qaRuntimeCreate).not.toContain('--security-opt no-new-privileges');
+    expect(steps[browserIndex]?.run).toContain('--security-opt no-new-privileges');
+    expect(steps[browserIndex]?.run).not.toContain('--cap-add=SYS_CHROOT');
+    expect(steps[browserIndex]?.run).not.toContain('apparmor=unconfined');
+    expect(qaRuntimeCreate).toContain('--security-opt no-new-privileges');
+    expect(qaRuntimeCreate).not.toContain('--cap-add=SYS_CHROOT');
+    expect(qaRuntimeCreate).not.toContain('apparmor=unconfined');
   });
 
   it('uploads immutable payload and result artifacts around finalization', () => {
@@ -464,7 +466,7 @@ esac
     );
   });
 
-  it('ships an enabled Chromium sandbox and exact-origin egress boundary', () => {
+  it('ships container-isolated Chromium and an exact-origin egress boundary', () => {
     const dockerfile = read('qa/Dockerfile');
     const action = read('qa/action.yml');
     const localRunner = read('qa/run-local.sh');
@@ -476,8 +478,8 @@ esac
 
     expect(action).toContain('seccomp=$GITHUB_ACTION_PATH/seccomp_profile.json');
     expect(action).toContain('--cap-drop=ALL');
-    expect(action).toContain('--cap-add=SYS_CHROOT');
-    expect(action.match(/--security-opt apparmor=unconfined/g)).toHaveLength(2);
+    expect(action).not.toContain('--cap-add=SYS_CHROOT');
+    expect(action).not.toContain('apparmor=unconfined');
     expect(dockerfile).toContain('HOME=/home/pwuser');
     expect(action.match(/uid=\$RUNTIME_UID,gid=\$RUNTIME_GID,mode=0700/g)).toHaveLength(3);
     expect(localRunner.match(/uid=\$CONTAINER_UID,gid=\$CONTAINER_GID,mode=0700/g)).toHaveLength(2);
@@ -489,9 +491,9 @@ esac
     expect(imageCi).toContain('/opt/juror/qa/smoke-chromium.mjs');
     expect(imageCi).toContain('run_chromium_smoke "$ARBITRARY_UID" "$ARBITRARY_GID"');
     expect(releaseWorkflow).toContain('/opt/juror/qa/smoke-chromium.mjs');
-    expect(read('qa/seccomp_profile.json')).toContain('Allow create user namespaces');
-    expect(browser).toContain('chromiumSandbox = true');
-    expect(browser).toContain('this.#options.chromiumSandbox ?? true');
+    expect(read('qa/seccomp_profile.json')).not.toContain('Allow create user namespaces');
+    expect(browser).toContain('chromiumSandbox = false');
+    expect(browser).toContain('this.#options.chromiumSandbox ?? false');
     expect(browser).toContain("channel: 'chromium'");
     expect(proxy).toContain('const allowed = new Set');
     expect(proxy).toContain("server.on('connect'");

--- a/test/supply-chain.test.ts
+++ b/test/supply-chain.test.ts
@@ -190,6 +190,10 @@ describe('supply-chain policy', () => {
     expect(steps[browserIndex]?.run).toContain('--network none');
     expect(steps[browserIndex]?.run).toContain('--user "$RUNTIME_USER"');
     expect(steps[browserIndex]?.run).toContain('seccomp=$GITHUB_ACTION_PATH/seccomp_profile.json');
+    expect(steps[browserIndex]?.run).toContain('--security-opt apparmor=unconfined');
+    expect(steps[browserIndex]?.run).toContain('--security-opt no-new-privileges');
+    expect(steps[qaIndex]?.run).toContain('--security-opt apparmor=unconfined');
+    expect(steps[qaIndex]?.run).toContain('--security-opt no-new-privileges');
   });
 
   it('uploads immutable payload and result artifacts around finalization', () => {
@@ -471,6 +475,7 @@ esac
     expect(action).toContain('seccomp=$GITHUB_ACTION_PATH/seccomp_profile.json');
     expect(action).toContain('--cap-drop=ALL');
     expect(action).toContain('--cap-add=SYS_CHROOT');
+    expect(action.match(/--security-opt apparmor=unconfined/g)).toHaveLength(2);
     expect(dockerfile).toContain('HOME=/home/pwuser');
     expect(action.match(/uid=\$RUNTIME_UID,gid=\$RUNTIME_GID,mode=0700/g)).toHaveLength(3);
     expect(localRunner.match(/uid=\$CONTAINER_UID,gid=\$CONTAINER_GID,mode=0700/g)).toHaveLength(2);


### PR DESCRIPTION
## Summary
- run Chromium in a portable outer container boundary for trusted E2E targets when runner-host AppArmor forbids Chromium user namespaces
- enforce non-root execution, zero capabilities, read-only filesystem, `no-new-privileges`, standard Docker seccomp restrictions, exact-origin egress, and resource limits
- verify those isolation properties plus a real rendered Chromium page before model execution
- create the evidence payload marker for browser/setup preflight failures
- bump the release to v1.4.5

## Production evidence
Platform smoke run 33500439255 proved v1.4.4 resolves and verifies correctly, then failed explicitly at the Chromium preflight with `No usable sandbox` on `cfke-docker`. It also exposed the missing preflight payload marker as `invalid_control_file`. A native Chromium namespace sandbox cannot be enabled portably from inside the job because Ubuntu AppArmor policy is controlled by the runner host.

## Validation
- Linux QA image smoke: https://github.com/Juror-AI/juror/actions/runs/33502407992
  - launched Chromium 151.0.7922.34 as both the image user and an arbitrary numeric host UID
  - asserted non-root, zero effective capabilities, `NoNewPrivs=1`, and seccomp mode 2 before launch
- 116 focused supply-chain, preflight, and QA outcome tests pass
- complete suite covered as 845 tests plus `proc.test.ts` (2 tests) in a separate clean process; all pass
- `npm run typecheck`
- `npm run check:secure-refs`
- `npm run build`
- `npm pack --ignore-scripts --dry-run`